### PR TITLE
feat: trust extra CA certificates via armada.caCertPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,65 @@ Configure the extension in VSCode Settings (`File → Preferences → Settings �
 | `armada.autoRefresh` | `true` | Automatically refresh job status |
 | `armada.refreshInterval` | `5000` | Auto-refresh interval in milliseconds |
 | `armada.maxJobsToShow` | `100` | Maximum number of jobs to display |
+| `armada.caCertPath` | *(empty)* | PEM CA bundle to trust for TLS, in addition to the system roots. See [Corporate networks](#corporate-networks-and-tls-inspecting-proxies) |
+
+### Corporate networks and TLS-inspecting proxies
+
+On networks that run a TLS-inspecting proxy (Zscaler, Netskope, or an internal
+CA), the certificate the extension actually receives is re-signed by the proxy.
+Node.js does not ship that CA, so every connection fails — usually as
+`UNAVAILABLE` with a certificate error such as
+`unable to verify the first certificate` or `self signed certificate in certificate chain`.
+
+Point `armada.caCertPath` at your organisation's CA bundle:
+
+```jsonc
+// .vscode/settings.json, or your user settings
+{
+  "armada.caCertPath": "~/certs/corporate-ca.pem"
+}
+```
+
+The bundle is added to Node's built-in root certificates rather than replacing
+them, so publicly-signed endpoints keep working. A leading `~` is expanded.
+
+Both the gRPC connection to the Armada server and the HTTPS connection to
+Lookout use the bundle. Certificate problems are reported in the
+**Armada** output channel (`View → Output → Armada`), including how many extra
+certificates were loaded.
+
+**Getting a PEM bundle**
+
+The file must be PEM (`-----BEGIN CERTIFICATE-----` blocks); a DER-encoded
+`.crt` will be rejected with a conversion hint. Multiple certificates can be
+concatenated into one file, and you generally want the whole chain.
+
+```bash
+# macOS: export everything in the system keychain
+security export -t certs -f pemseq \
+  -k /Library/Keychains/System.keychain > ~/certs/corporate-ca.pem
+
+# Linux: the distro bundle usually already contains company CAs
+cp /etc/ssl/certs/ca-certificates.crt ~/certs/corporate-ca.pem
+
+# Convert a DER/.crt file your IT team gave you
+openssl x509 -inform der -in corporate-ca.crt -out ~/certs/corporate-ca.pem
+
+# Capture the chain a proxy presents for your Armada server
+openssl s_client -showcerts -connect armada.example.com:443 </dev/null \
+  2>/dev/null > ~/certs/corporate-ca.pem
+```
+
+A `caCertPath` set on the active `armadactl` context takes precedence over this
+setting, so per-cluster bundles are possible:
+
+```yaml
+currentContext: corp
+contexts:
+  corp:
+    armadaUrl: https://armada.example.com
+    caCertPath: ~/certs/corporate-ca.pem
+```
 
 ## Local Development Setup
 

--- a/package.json
+++ b/package.json
@@ -272,6 +272,11 @@
           "default": "",
           "description": "Path to armadactl config file (default: ~/.armadactl.yaml)"
         },
+        "armada.caCertPath": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Path to a PEM CA certificate bundle to trust for TLS, in addition to the system roots. Needed on corporate networks where a TLS-inspecting proxy (Zscaler, Netskope, a company CA) re-signs traffic, which otherwise fails with `UNAVAILABLE` and a certificate error. Supports `~`. A `caCertPath` on the active armadactl context takes precedence over this setting."
+        },
         "armada.autoRefresh": {
           "type": "boolean",
           "default": true,

--- a/src/api/lookoutClient.ts
+++ b/src/api/lookoutClient.ts
@@ -1,9 +1,17 @@
 import * as https from 'https';
 import * as http from 'http';
+import { describeCertificateError } from '../grpc/caCerts';
 
 export interface LookoutConfig {
     lookoutUrl: string; // e.g., "https://lookout.armada.example.com"
     authHeader?: string; // Optional Bearer token or other auth header value
+    /**
+     * Extra CA certificates to trust, already merged with the system roots.
+     * Needed when a corporate TLS proxy re-signs HTTPS traffic.
+     */
+    caCerts?: Buffer;
+    /** The configured path, used only to make certificate errors actionable. */
+    caCertPath?: string;
 }
 
 export interface LookoutJob {
@@ -52,10 +60,21 @@ export interface LookoutJobsResponse {
 export class LookoutClient {
     private lookoutUrl: string;
     private authHeader?: string;
+    private httpsAgent?: https.Agent;
+    private caCertPath?: string;
 
     constructor(config: LookoutConfig) {
         this.lookoutUrl = config.lookoutUrl.replace(/\/$/, ''); // Remove trailing slash
         this.authHeader = config.authHeader;
+        if (config.caCerts) {
+            // `ca` replaces the default roots, so the caller passes a bundle
+            // that already includes them.
+            this.httpsAgent = new https.Agent({ ca: config.caCerts });
+            // Only remembered when the bundle actually loaded: a path with no
+            // certs behind it must not produce "your bundle is missing the
+            // signing CA" advice about a file that was never read.
+            this.caCertPath = config.caCertPath;
+        }
     }
 
     /**
@@ -168,13 +187,16 @@ export class LookoutClient {
                 headers['Authorization'] = this.authHeader;
             }
 
-            const options = {
+            const options: https.RequestOptions = {
                 hostname: urlObj.hostname,
                 port: urlObj.port || (isHttps ? 443 : 80),
                 path: urlObj.pathname + urlObj.search,
                 method: 'POST',
                 headers
             };
+            if (isHttps && this.httpsAgent) {
+                options.agent = this.httpsAgent;
+            }
 
             const req = client.request(options, (res) => {
                 let data = '';
@@ -198,7 +220,11 @@ export class LookoutClient {
             });
 
             req.on('error', (error) => {
-                reject(new Error(`HTTP request failed: ${error.message}`));
+                // Surface the CA-bundle remedy here too; a bare "HTTP request
+                // failed: unable to verify the first certificate" gives the user
+                // nothing to act on.
+                const certHint = describeCertificateError(error.message, this.caCertPath);
+                reject(new Error(`HTTP request failed: ${error.message}${certHint}`));
             });
 
             req.write(JSON.stringify(body));

--- a/src/commands/browseJobSets.ts
+++ b/src/commands/browseJobSets.ts
@@ -5,6 +5,7 @@ import { LookoutClient } from '../api/lookoutClient';
 import { JobState } from '../types/armada';
 import { ResolvedConfig } from '../types/config';
 import { buildAuthHeader } from '../grpc/auth';
+import { buildTrustStore } from '../grpc/caCerts';
 
 const LOOKOUT_LOCALHOST_DEFAULT = 'http://localhost:30000';
 
@@ -33,7 +34,20 @@ export async function browseJobSetsCommand(
         } catch (error: any) {
             console.warn(`[Armada] Could not build Lookout auth header: ${error.message}`);
         }
-        const lookoutClient = new LookoutClient({ lookoutUrl, authHeader });
+        // Trust the same extra CAs as the gRPC clients, so a corporate TLS
+        // proxy in front of Lookout does not break job-set browsing.
+        let caCerts: Buffer | undefined;
+        try {
+            caCerts = buildTrustStore(config?.caCertPath);
+        } catch (error: any) {
+            console.warn(`[Armada] ${error.message}`);
+        }
+        const lookoutClient = new LookoutClient({
+            lookoutUrl,
+            authHeader,
+            caCerts,
+            caCertPath: config?.caCertPath
+        });
 
         // Step 1: Select a queue
         const activeQueuesMap = await vscode.window.withProgress(

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -74,6 +74,7 @@ export class ConfigManager {
                 binocularsUrlPattern: context.binocularsUrlPattern,
                 lookoutUrl: context.lookoutUrl,
                 forceNoTls: context.forceNoTls,
+                caCertPath: this.resolveCaCertPath(context.caCertPath),
                 currentContext: contextName,
                 auth: this.extractAuth(context)
             };
@@ -84,11 +85,28 @@ export class ConfigManager {
             return {
                 armadaUrl: config.armadaUrl,
                 forceNoTls: (config as any).forceNoTls,
+                caCertPath: this.resolveCaCertPath((config as any).caCertPath),
                 auth: this.extractAuth(config as any)
             };
         }
 
         return null;
+    }
+
+    /**
+     * Pick the CA bundle to trust for TLS.
+     *
+     * A per-context `caCertPath` in the armadactl config wins, so different
+     * clusters can use different bundles; the `armada.caCertPath` setting is the
+     * fallback for the common case of one corporate proxy in front of
+     * everything.
+     */
+    private resolveCaCertPath(contextCaCertPath?: string): string | undefined {
+        if (contextCaCertPath && contextCaCertPath.trim() !== '') {
+            return contextCaCertPath;
+        }
+        const setting = vscode.workspace.getConfiguration('armada').get<string>('caCertPath');
+        return setting && setting.trim() !== '' ? setting : undefined;
     }
 
     /**

--- a/src/config/resolver.ts
+++ b/src/config/resolver.ts
@@ -51,6 +51,7 @@ export function resolveArmadaConfig(config: ArmadaConfig): ResolvedConfig | null
             armadaUrl: context.armadaUrl,
             binocularsUrl: context.binocularsUrl,
             binocularsUrlPattern: context.binocularsUrlPattern,
+            caCertPath: context.caCertPath,
             currentContext: contextName,
             auth: extractAuth(context)
         };
@@ -60,6 +61,7 @@ export function resolveArmadaConfig(config: ArmadaConfig): ResolvedConfig | null
     if (config.armadaUrl) {
         return {
             armadaUrl: config.armadaUrl,
+            caCertPath: config.caCertPath,
             auth: extractAuth(config as any)
         };
     }

--- a/src/grpc/armadaClient.ts
+++ b/src/grpc/armadaClient.ts
@@ -1,9 +1,11 @@
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import * as path from 'path';
+import * as tls from 'tls';
 import { ResolvedConfig } from '../types/config';
 import { ArmadaJobSpec, SubmitJobResponse, JobEventMessage, Queue, ConnectionState, ConnectionTestResult } from '../types/armada';
 import { buildAuthHeader, isSecureCredentials, makeAuthInterceptor, withCallCredentials } from './auth';
+import { buildTrustStore, countCertificates, describeCertificateError, resolveCertPath } from './caCerts';
 
 /**
  * Strip any `http://` or `https://` scheme prefix from a URL so that the
@@ -36,9 +38,16 @@ export function usesTls(url: string, forceNoTls?: boolean): boolean {
  * port 443.  Passing `forceNoTls: true` always returns insecure credentials
  * regardless of the URL (useful for development / plain-text servers).
  */
-export function selectCredentials(url: string, forceNoTls?: boolean): grpc.ChannelCredentials {
+export function selectCredentials(
+    url: string,
+    forceNoTls?: boolean,
+    rootCerts?: Buffer
+): grpc.ChannelCredentials {
     return usesTls(url, forceNoTls)
-        ? grpc.credentials.createSsl()
+        // A CA bundle replaces the default roots for this channel. Corporate
+        // TLS-inspecting proxies re-sign traffic with a CA that is not in
+        // Node's bundled root store, so without this the handshake fails.
+        ? grpc.credentials.createSsl(rootCerts)
         : grpc.credentials.createInsecure();
 }
 
@@ -51,6 +60,8 @@ export class ArmadaClient {
     private config: ResolvedConfig;
     private initialized: boolean = false;
     private cachedAuthHeader: string | undefined;
+    private trustStore: Buffer | undefined;
+    private trustStoreLoaded: boolean = false;
 
     connectionState: ConnectionState = 'unknown';
     onConnectionStateChange: ((state: ConnectionState, detail?: string) => void) | undefined;
@@ -77,8 +88,17 @@ export class ArmadaClient {
         const suffix = details ? ` Server said: ${details}` : '';
 
         if (code === 14) {
-            this.logError(`UNAVAILABLE from ${this.config.armadaUrl}.${suffix}`);
-            this.updateConnectionState('error', `Cannot reach Armada server at ${this.config.armadaUrl}. Is armada-server running?`);
+            // A certificate rejection arrives as UNAVAILABLE with the OpenSSL
+            // reason buried in `details`, which reads like the server is down.
+            // Corporate TLS proxies are the usual cause, so name the remedy.
+            const certHint = describeCertificateError(details, this.activeCertPath());
+            this.logError(`UNAVAILABLE from ${this.config.armadaUrl}.${suffix}${certHint}`);
+            this.updateConnectionState(
+                'error',
+                certHint
+                    ? `TLS certificate verification failed for ${this.config.armadaUrl}.${certHint}`
+                    : `Cannot reach Armada server at ${this.config.armadaUrl}. Is armada-server running?`
+            );
         } else if (code === 13) {
             this.logError(`INTERNAL error from ${this.config.armadaUrl}.${suffix}`);
             this.updateConnectionState('error', `Armada server returned an internal error.${suffix}`);
@@ -199,7 +219,7 @@ export class ArmadaClient {
      * unless `forceNoTls` is set in the config.
      */
     private getCredentials(url: string): grpc.ChannelCredentials {
-        const channelCredentials = selectCredentials(url, this.config.forceNoTls);
+        const channelCredentials = selectCredentials(url, this.config.forceNoTls, this.getTrustStore());
 
         // Attach the credentials from the armadactl config to every call on
         // this channel. Without this the extension parses basicAuth/execAuth
@@ -225,6 +245,51 @@ export class ArmadaClient {
 
     private hasAuth(): boolean {
         return !!this.config.auth && this.config.auth.type !== 'none';
+    }
+
+    /**
+     * The CA bundle to trust, read once per client.
+     *
+     * A configured-but-unreadable bundle is reported and then ignored: failing
+     * the whole client would leave the user with no UI at all, while continuing
+     * with the default roots at least keeps publicly-signed endpoints working.
+     * The message says which file to fix.
+     */
+    private getTrustStore(): Buffer | undefined {
+        if (this.trustStoreLoaded) {
+            return this.trustStore;
+        }
+        this.trustStoreLoaded = true;
+
+        try {
+            this.trustStore = buildTrustStore(this.config.caCertPath);
+            if (this.trustStore && this.config.caCertPath) {
+                const extra = countCertificates(this.trustStore) - tls.rootCertificates.length;
+                this.logInfo(
+                    `Trusting ${extra} extra CA certificate(s) from ` +
+                    `${resolveCertPath(this.config.caCertPath)} in addition to the system roots.`
+                );
+            }
+        } catch (error: any) {
+            this.trustStore = undefined;
+            this.logError(
+                `${error.message} Falling back to the default certificate store, ` +
+                'so connections through a TLS-inspecting proxy will likely fail.'
+            );
+        }
+
+        return this.trustStore;
+    }
+
+    /**
+     * The CA bundle path actually in effect, or undefined if none is.
+     *
+     * A configured-but-unloadable bundle is *not* in effect: telling the user
+     * their bundle "did not contain the signing CA" would send them auditing a
+     * file that was never read. The load failure is reported separately.
+     */
+    private activeCertPath(): string | undefined {
+        return this.getTrustStore() ? this.config.caCertPath : undefined;
     }
 
     /**
@@ -271,6 +336,13 @@ export class ArmadaClient {
             return this.cachedAuthHeader;
         }
         return buildAuthHeader(this.config.auth);
+    }
+
+    private logInfo(message: string): void {
+        console.log(`[Armada] ${message}`);
+        if (this.onLogMessage) {
+            this.onLogMessage(message);
+        }
     }
 
     private logWarning(message: string): void {

--- a/src/grpc/caCerts.ts
+++ b/src/grpc/caCerts.ts
@@ -1,0 +1,157 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as tls from 'tls';
+
+/**
+ * Raised when a configured CA bundle cannot be used. Carries the resolved path
+ * so callers can tell the user exactly which file to fix.
+ */
+export class CaCertError extends Error {
+    readonly certPath: string;
+
+    constructor(certPath: string, message: string) {
+        super(message);
+        this.name = 'CaCertError';
+        this.certPath = certPath;
+    }
+}
+
+/**
+ * Expand a leading `~` and make the path absolute, so settings can use the
+ * same shorthand users type in a shell.
+ */
+export function resolveCertPath(certPath: string): string {
+    const expanded = certPath.startsWith('~')
+        ? path.join(os.homedir(), certPath.slice(1))
+        : certPath;
+    return path.resolve(expanded);
+}
+
+/**
+ * Read a PEM CA bundle from disk.
+ *
+ * Returns undefined when no path is configured, which means "use Node's
+ * built-in trust store". Throws CaCertError when a path *is* configured but
+ * unusable — a silent fallback there would look identical to a genuine
+ * certificate rejection and send users chasing the wrong problem.
+ */
+export function loadCaCerts(certPath: string | undefined): Buffer | undefined {
+    if (!certPath || certPath.trim() === '') {
+        return undefined;
+    }
+
+    const resolved = resolveCertPath(certPath.trim());
+
+    let contents: Buffer;
+    try {
+        contents = fs.readFileSync(resolved);
+    } catch (error: any) {
+        const reason = error?.code === 'ENOENT'
+            ? 'file not found'
+            : error?.code === 'EACCES'
+                ? 'permission denied'
+                : error?.message ?? String(error);
+        throw new CaCertError(resolved, `Cannot read CA certificate bundle at ${resolved}: ${reason}`);
+    }
+
+    if (!contents.includes('-----BEGIN CERTIFICATE-----')) {
+        throw new CaCertError(
+            resolved,
+            `${resolved} does not look like a PEM certificate bundle ` +
+            '(no "-----BEGIN CERTIFICATE-----" block found). ' +
+            'DER/CRT files must be converted first: ' +
+            `openssl x509 -inform der -in <file> -out bundle.pem`
+        );
+    }
+
+    return contents;
+}
+
+/**
+ * Count the certificates in a PEM bundle, for logging. Corporate bundles
+ * usually contain a whole chain, and the count is a quick sanity check that the
+ * right file was picked up.
+ */
+export function countCertificates(pem: Buffer): number {
+    return pem.toString('utf-8').split('-----BEGIN CERTIFICATE-----').length - 1;
+}
+
+/**
+ * OpenSSL / Node reasons that mean "the peer's certificate was not trusted",
+ * as opposed to a genuinely unreachable server. gRPC surfaces these inside an
+ * UNAVAILABLE error's `details` string.
+ */
+const CERT_ERROR_PATTERNS = [
+    'unable to verify the first certificate',
+    'unable to get local issuer certificate',
+    'self signed certificate',
+    'self-signed certificate',
+    'certificate has expired',
+    'certificate verify failed',
+    'CERT_UNTRUSTED',
+    'DEPTH_ZERO_SELF_SIGNED_CERT',
+    'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    'ERR_TLS_CERT_ALTNAME_INVALID'
+];
+
+/**
+ * If the given error text looks like a certificate rejection, return actionable
+ * advice; otherwise return an empty string.
+ *
+ * Certificate failures reach the user as a bare gRPC UNAVAILABLE, which reads
+ * as "the server is down" and sends people looking in the wrong place.
+ */
+export function describeCertificateError(details: string, configuredCertPath?: string): string {
+    if (!details) {
+        return '';
+    }
+    const lowered = details.toLowerCase();
+    const isCertError = CERT_ERROR_PATTERNS.some(p => lowered.includes(p.toLowerCase()));
+    if (!isCertError) {
+        return '';
+    }
+
+    if (configuredCertPath) {
+        return ' The server certificate was rejected even though ' +
+            `"armada.caCertPath" is set to ${resolveCertPath(configuredCertPath)}. ` +
+            'Check that this bundle contains the CA that signed the server certificate ' +
+            '(and the full intermediate chain).';
+    }
+
+    return ' This looks like a TLS certificate that the default trust store does not ' +
+        'recognise, which is typical of a corporate TLS-inspecting proxy (Zscaler, ' +
+        'Netskope, a company CA). Export your organisation\'s CA bundle as PEM and set ' +
+        'the "armada.caCertPath" setting to it.';
+}
+
+/**
+ * Append a PEM bundle to Node's built-in root certificates.
+ *
+ * Both `grpc.credentials.createSsl(rootCerts)` and the `ca` option on
+ * `https.Agent` *replace* the trust store rather than adding to it. Handing
+ * either one a corporate bundle alone would make the proxied endpoint work
+ * while breaking every publicly-signed one — the same trap as setting
+ * `SSL_CERT_FILE` instead of `NODE_EXTRA_CA_CERTS`. Concatenating with
+ * `tls.rootCertificates` keeps both working.
+ */
+export function withSystemRoots(extraCerts: Buffer): Buffer {
+    const systemRoots = tls.rootCertificates.join('\n');
+    return Buffer.concat([
+        Buffer.from(systemRoots, 'utf-8'),
+        Buffer.from('\n', 'utf-8'),
+        extraCerts
+    ]);
+}
+
+/**
+ * Resolve the configured CA path into a bundle ready to hand to gRPC or
+ * `https.Agent`, with Node's roots retained.
+ *
+ * Returns undefined when nothing is configured, which leaves the default trust
+ * store in place.
+ */
+export function buildTrustStore(certPath: string | undefined): Buffer | undefined {
+    const extraCerts = loadCaCerts(certPath);
+    return extraCerts ? withSystemRoots(extraCerts) : undefined;
+}

--- a/src/test/mock/armadaServer.ts
+++ b/src/test/mock/armadaServer.ts
@@ -193,18 +193,27 @@ export class MockArmadaServer {
         callback(null, { job_errors: jobErrors });
     }
 
-    /** Start the server on a dynamic port. Returns the assigned port. */
-    async start(): Promise<number> {
+    /**
+     * Start the server on a dynamic port. Returns the assigned port.
+     *
+     * Passing a key/cert pair serves TLS instead of plaintext, which lets tests
+     * exercise certificate verification against a real handshake.
+     */
+    async start(tlsIdentity?: { key: Buffer; cert: Buffer }): Promise<number> {
+        const credentials = tlsIdentity
+            ? grpc.ServerCredentials.createSsl(
+                null,
+                [{ private_key: tlsIdentity.key, cert_chain: tlsIdentity.cert }],
+                false
+            )
+            : grpc.ServerCredentials.createInsecure();
+
         return new Promise((resolve, reject) => {
-            this.server.bindAsync(
-                '127.0.0.1:0',
-                grpc.ServerCredentials.createInsecure(),
-                (err, port) => {
-                    if (err) { reject(err); return; }
-                    this.port = port;
-                    resolve(port);
-                }
-            );
+            this.server.bindAsync('127.0.0.1:0', credentials, (err, port) => {
+                if (err) { reject(err); return; }
+                this.port = port;
+                resolve(port);
+            });
         });
     }
 

--- a/src/test/mock/selfSignedCert.ts
+++ b/src/test/mock/selfSignedCert.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface SelfSignedCert {
+    key: Buffer;
+    cert: Buffer;
+    /** Directory holding the generated files; remove it when done. */
+    dir: string;
+}
+
+/**
+ * True when `openssl` is available to generate a throwaway certificate.
+ * Tests that need a real TLS handshake skip themselves when it is not.
+ */
+export function opensslAvailable(): boolean {
+    try {
+        execFileSync('openssl', ['version'], { stdio: 'ignore' });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Generate a short-lived self-signed certificate for localhost in a temp dir.
+ *
+ * Generated per run rather than committed: a checked-in private key trips
+ * secret scanners and eventually expires. This is throwaway test-only material.
+ */
+export function generateSelfSignedCert(): SelfSignedCert {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'armada-tls-'));
+    const keyPath = path.join(dir, 'server.key');
+    const certPath = path.join(dir, 'server.crt');
+
+    execFileSync('openssl', [
+        'req', '-x509',
+        '-newkey', 'rsa:2048',
+        '-nodes',
+        '-keyout', keyPath,
+        '-out', certPath,
+        '-days', '1',
+        '-subj', '/CN=localhost',
+        '-addext', 'subjectAltName=DNS:localhost,IP:127.0.0.1'
+    ], { stdio: 'ignore' });
+
+    return {
+        key: fs.readFileSync(keyPath),
+        cert: fs.readFileSync(certPath),
+        dir
+    };
+}
+
+export function cleanupSelfSignedCert(generated: SelfSignedCert): void {
+    fs.rmSync(generated.dir, { recursive: true, force: true });
+}

--- a/src/test/unit/api/lookoutClient.test.ts
+++ b/src/test/unit/api/lookoutClient.test.ts
@@ -1,0 +1,112 @@
+import * as assert from 'assert';
+import * as https from 'https';
+import { AddressInfo } from 'net';
+import { LookoutClient, LookoutJobsRequest } from '../../../api/lookoutClient';
+import {
+    cleanupSelfSignedCert,
+    generateSelfSignedCert,
+    opensslAvailable,
+    SelfSignedCert
+} from '../../mock/selfSignedCert';
+
+/** Minimal well-formed request; the stub server ignores the body. */
+const REQUEST: LookoutJobsRequest = {
+    filters: [],
+    order: { field: 'jobId', direction: 'ASC' },
+    take: 10
+};
+
+/**
+ * The Lookout client talks HTTPS rather than gRPC, so it needs its own trust
+ * store wiring. These tests use a real self-signed HTTPS server: the same
+ * request must fail with the default roots and succeed once the CA is supplied.
+ */
+describe('LookoutClient TLS trust', function () {
+    let generated: SelfSignedCert | undefined;
+    let server: https.Server | undefined;
+    let lookoutUrl: string;
+
+    before(function (done) {
+        if (!opensslAvailable()) {
+            // Nothing to assert without a certificate to serve.
+            this.skip();
+            return;
+        }
+        this.timeout(30_000);
+
+        generated = generateSelfSignedCert();
+        server = https.createServer(
+            { key: generated.key, cert: generated.cert },
+            (_req, res) => {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ jobs: [] }));
+            }
+        );
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server!.address() as AddressInfo;
+            lookoutUrl = `https://localhost:${port}`;
+            done();
+        });
+    });
+
+    after(function (done) {
+        const finish = () => {
+            if (generated) { cleanupSelfSignedCert(generated); }
+            done();
+        };
+        if (server) { server.close(finish); } else { finish(); }
+    });
+
+    it('rejects a self-signed server when the CA is not trusted', async function () {
+        this.timeout(30_000);
+        const client = new LookoutClient({ lookoutUrl });
+        await assert.rejects(
+            () => client.getJobs(REQUEST),
+            (error: Error) => {
+                assert.match(error.message, /certificate/i);
+                return true;
+            }
+        );
+    });
+
+    it('succeeds once the signing certificate is trusted', async function () {
+        this.timeout(30_000);
+        const client = new LookoutClient({
+            lookoutUrl,
+            caCerts: Buffer.from(generated!.cert)
+        });
+        const jobs = await client.getJobs(REQUEST);
+        assert.deepStrictEqual(jobs, []);
+    });
+
+    it('suggests caCertPath when a certificate is rejected and none is set', async function () {
+        this.timeout(30_000);
+        const client = new LookoutClient({ lookoutUrl });
+        await assert.rejects(
+            () => client.getJobs(REQUEST),
+            (error: Error) => {
+                assert.match(error.message, /caCertPath/);
+                return true;
+            }
+        );
+    });
+
+    it('does not blame a bundle that never loaded', async function () {
+        this.timeout(30_000);
+        // caCertPath is set but caCerts is absent, i.e. the bundle failed to
+        // load. Saying "your bundle lacks the signing CA" would point the user
+        // at a file that was never read.
+        const client = new LookoutClient({
+            lookoutUrl,
+            caCertPath: '/nonexistent/corp.pem'
+        });
+        await assert.rejects(
+            () => client.getJobs(REQUEST),
+            (error: Error) => {
+                assert.doesNotMatch(error.message, /rejected even though/);
+                assert.match(error.message, /caCertPath/);
+                return true;
+            }
+        );
+    });
+});

--- a/src/test/unit/grpc/caCerts.test.ts
+++ b/src/test/unit/grpc/caCerts.test.ts
@@ -1,0 +1,165 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as tls from 'tls';
+import {
+    buildTrustStore,
+    CaCertError,
+    countCertificates,
+    describeCertificateError,
+    loadCaCerts,
+    resolveCertPath,
+    withSystemRoots
+} from '../../../grpc/caCerts';
+
+/** A syntactically well-formed PEM block; contents are never parsed by these tests. */
+const FAKE_PEM = [
+    '-----BEGIN CERTIFICATE-----',
+    'MIIBfakecertificatecontentsthatarenotparsedbythesetests',
+    '-----END CERTIFICATE-----',
+    ''
+].join('\n');
+
+describe('resolveCertPath', () => {
+    it('expands a leading tilde to the home directory', () => {
+        assert.strictEqual(
+            resolveCertPath('~/certs/corp.pem'),
+            path.join(os.homedir(), 'certs/corp.pem')
+        );
+    });
+
+    it('leaves an absolute path alone', () => {
+        assert.strictEqual(resolveCertPath('/etc/ssl/certs/corp.pem'), '/etc/ssl/certs/corp.pem');
+    });
+
+    it('makes a relative path absolute', () => {
+        assert.ok(path.isAbsolute(resolveCertPath('corp.pem')));
+    });
+});
+
+describe('loadCaCerts', () => {
+    let tmpDir: string;
+
+    before(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'armada-ca-test-'));
+    });
+
+    after(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns undefined when no path is configured', () => {
+        assert.strictEqual(loadCaCerts(undefined), undefined);
+        assert.strictEqual(loadCaCerts(''), undefined);
+        assert.strictEqual(loadCaCerts('   '), undefined);
+    });
+
+    it('reads a PEM bundle from disk', () => {
+        const certPath = path.join(tmpDir, 'good.pem');
+        fs.writeFileSync(certPath, FAKE_PEM);
+        const loaded = loadCaCerts(certPath);
+        assert.ok(loaded);
+        assert.ok(loaded.toString('utf-8').includes('-----BEGIN CERTIFICATE-----'));
+    });
+
+    it('throws a CaCertError naming the file when it does not exist', () => {
+        const missing = path.join(tmpDir, 'nope.pem');
+        assert.throws(
+            () => loadCaCerts(missing),
+            (error: Error) => {
+                assert.ok(error instanceof CaCertError);
+                assert.match(error.message, /file not found/);
+                assert.ok(error.message.includes(missing), 'message should name the path');
+                return true;
+            }
+        );
+    });
+
+    it('rejects a file that is not PEM, pointing at the DER conversion', () => {
+        // A DER-encoded .crt is the most common wrong-format mistake, and
+        // handing its bytes to gRPC fails with an opaque error.
+        const derPath = path.join(tmpDir, 'corp.crt');
+        fs.writeFileSync(derPath, Buffer.from([0x30, 0x82, 0x01, 0x0a, 0x02, 0x01]));
+        assert.throws(
+            () => loadCaCerts(derPath),
+            (error: Error) => {
+                assert.ok(error instanceof CaCertError);
+                assert.match(error.message, /does not look like a PEM certificate bundle/);
+                assert.match(error.message, /openssl x509 -inform der/);
+                return true;
+            }
+        );
+    });
+});
+
+describe('withSystemRoots', () => {
+    it('keeps the system roots and appends the extra certificates', () => {
+        // Replacing rather than appending is the classic mistake here — it makes
+        // the proxied endpoint work while breaking every public CA.
+        const combined = withSystemRoots(Buffer.from(FAKE_PEM));
+        assert.strictEqual(
+            countCertificates(combined),
+            tls.rootCertificates.length + 1,
+            'combined bundle should hold every system root plus the extra cert'
+        );
+    });
+});
+
+describe('buildTrustStore', () => {
+    let tmpDir: string;
+
+    before(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'armada-ca-store-'));
+    });
+
+    after(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns undefined when nothing is configured, leaving defaults in place', () => {
+        assert.strictEqual(buildTrustStore(undefined), undefined);
+    });
+
+    it('returns system roots plus the configured bundle', () => {
+        const certPath = path.join(tmpDir, 'corp.pem');
+        fs.writeFileSync(certPath, FAKE_PEM);
+        const store = buildTrustStore(certPath);
+        assert.ok(store);
+        assert.strictEqual(countCertificates(store), tls.rootCertificates.length + 1);
+    });
+});
+
+describe('describeCertificateError', () => {
+    it('returns nothing for an unrelated error', () => {
+        assert.strictEqual(describeCertificateError('connection refused'), '');
+    });
+
+    it('returns nothing for empty details', () => {
+        assert.strictEqual(describeCertificateError(''), '');
+    });
+
+    it('suggests caCertPath when a cert is untrusted and none is configured', () => {
+        const hint = describeCertificateError('unable to verify the first certificate');
+        assert.match(hint, /armada\.caCertPath/);
+        assert.match(hint, /proxy/i);
+    });
+
+    it('recognises a self-signed certificate', () => {
+        assert.match(describeCertificateError('self signed certificate in certificate chain'), /caCertPath/);
+    });
+
+    it('recognises an expired certificate', () => {
+        assert.match(describeCertificateError('certificate has expired'), /caCertPath/);
+    });
+
+    it('is case-insensitive', () => {
+        assert.match(describeCertificateError('UNABLE TO GET LOCAL ISSUER CERTIFICATE'), /caCertPath/);
+    });
+
+    it('says the configured bundle did not match when one is already set', () => {
+        const hint = describeCertificateError('unable to verify the first certificate', '/tmp/corp.pem');
+        assert.match(hint, /\/tmp\/corp\.pem/);
+        assert.match(hint, /intermediate chain/);
+    });
+});

--- a/src/test/unit/grpc/tlsTrust.test.ts
+++ b/src/test/unit/grpc/tlsTrust.test.ts
@@ -1,0 +1,142 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tls from 'tls';
+import { MockArmadaServer } from '../../mock/armadaServer';
+import { ArmadaClient } from '../../../grpc/armadaClient';
+import {
+    cleanupSelfSignedCert,
+    generateSelfSignedCert,
+    opensslAvailable,
+    SelfSignedCert
+} from '../../mock/selfSignedCert';
+
+/**
+ * End-to-end proof that `armada.caCertPath` changes the outcome of a real TLS
+ * handshake: the same server is unreachable with the default trust store and
+ * reachable once its CA is trusted.
+ *
+ * This is the scenario behind the setting — a corporate TLS-inspecting proxy
+ * presents a certificate signed by a CA that Node does not ship.
+ */
+describe('TLS trust via caCertPath', function () {
+    let generated: SelfSignedCert | undefined;
+    let server: MockArmadaServer | undefined;
+    let armadaUrl: string;
+    let certPath: string;
+
+    before(async function () {
+        if (!opensslAvailable()) {
+            // Nothing to assert without a certificate to serve.
+            this.skip();
+        }
+        // Key generation plus two handshakes can exceed mocha's 2s default.
+        this.timeout(30_000);
+
+        generated = generateSelfSignedCert();
+        certPath = path.join(generated.dir, 'server.crt');
+        fs.writeFileSync(certPath, generated.cert);
+
+        server = new MockArmadaServer();
+        const port = await server.start({ key: generated.key, cert: generated.cert });
+        armadaUrl = `https://localhost:${port}`;
+    });
+
+    after(async function () {
+        if (server) { await server.stop(); }
+        if (generated) { cleanupSelfSignedCert(generated); }
+    });
+
+    it('fails against a self-signed server when the CA is not trusted', async function () {
+        this.timeout(30_000);
+        const client = new ArmadaClient({ armadaUrl, auth: { type: 'none' } });
+        const result = await client.testConnection();
+        assert.strictEqual(result.ok, false, 'untrusted certificate should not connect');
+    });
+
+    it('succeeds once caCertPath supplies the signing certificate', async function () {
+        this.timeout(30_000);
+        const client = new ArmadaClient({
+            armadaUrl,
+            caCertPath: certPath,
+            auth: { type: 'none' }
+        });
+        const result = await client.testConnection();
+        assert.strictEqual(
+            result.ok,
+            true,
+            `expected a successful handshake with caCertPath set, got: ${result.message ?? '(no error)'}`
+        );
+    });
+
+    it('reports a certificate error rather than a bare "is the server running?"', async function () {
+        this.timeout(30_000);
+        const messages: string[] = [];
+        const client = new ArmadaClient({ armadaUrl, auth: { type: 'none' } });
+        client.onLogMessage = (message) => messages.push(message);
+
+        await client.testConnection();
+
+        const joined = messages.join('\n');
+        assert.match(joined, /caCertPath/, `expected caCertPath guidance, got: ${joined}`);
+    });
+
+    it('still trusts public CAs when an extra bundle is configured', async function () {
+        this.timeout(30_000);
+        // Regression guard: `createSsl(rootCerts)` replaces the trust store, so
+        // a naive implementation would break every publicly-signed endpoint the
+        // moment a corporate bundle is configured.
+        const client = new ArmadaClient({
+            armadaUrl,
+            caCertPath: certPath,
+            auth: { type: 'none' }
+        });
+        const store = (client as any).getTrustStore() as Buffer;
+        const count = store.toString('utf-8').split('-----BEGIN CERTIFICATE-----').length - 1;
+        assert.strictEqual(count, tls.rootCertificates.length + 1);
+    });
+
+    it('falls back to default roots and logs when the bundle is missing', async function () {
+        this.timeout(30_000);
+        const messages: string[] = [];
+        const client = new ArmadaClient({
+            armadaUrl,
+            caCertPath: path.join(generated!.dir, 'absent.pem'),
+            auth: { type: 'none' }
+        });
+        client.onLogMessage = (message) => messages.push(message);
+
+        // Should not throw; the client stays usable with the default store.
+        const result = await client.testConnection();
+        assert.strictEqual(result.ok, false);
+
+        const joined = messages.join('\n');
+        assert.match(joined, /file not found/);
+        assert.match(joined, /absent\.pem/);
+    });
+
+    it('does not blame an unloadable bundle for the certificate rejection', async function () {
+        this.timeout(30_000);
+        // The bundle never loaded, so the default store is what rejected the
+        // certificate. Claiming the configured bundle lacked the signing CA
+        // would send the user auditing a file that was never read.
+        const messages: string[] = [];
+        const client = new ArmadaClient({
+            armadaUrl,
+            caCertPath: path.join(generated!.dir, 'absent.pem'),
+            auth: { type: 'none' }
+        });
+        client.onLogMessage = (message) => messages.push(message);
+
+        await client.testConnection();
+
+        const joined = messages.join('\n');
+        assert.doesNotMatch(
+            joined,
+            /rejected even though/,
+            `should not claim the bundle is in effect, got: ${joined}`
+        );
+        // Still guides the user toward configuring a working bundle.
+        assert.match(joined, /caCertPath/);
+    });
+});

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -23,6 +23,7 @@ export interface ArmadaContext {
     binocularsUrlPattern?: string; // Pattern with {CLUSTER_ID} placeholder
     lookoutUrl?: string; // Lookout v2 UI/API base URL, e.g. "https://lookout.armada.example.com"
     forceNoTls?: boolean; // When true, use insecure (plaintext) gRPC even if TLS is detected
+    caCertPath?: string; // PEM bundle of extra CAs to trust (corporate TLS proxies)
     openIdConnect?: OpenIdConnect;
     execAuth?: ExecAuth;
     basicAuth?: {
@@ -37,6 +38,7 @@ export interface ArmadaConfig {
     // Legacy format (direct config without contexts)
     armadaUrl?: string;
     forceNoTls?: boolean; // When true, use insecure (plaintext) gRPC even if TLS is detected
+    caCertPath?: string; // PEM bundle of extra CAs to trust (corporate TLS proxies)
     openIdConnect?: OpenIdConnect;
     execAuth?: ExecAuth;
 }
@@ -47,6 +49,7 @@ export interface ResolvedConfig {
     binocularsUrlPattern?: string; // Pattern with {CLUSTER_ID} placeholder
     lookoutUrl?: string; // Lookout v2 UI/API base URL
     forceNoTls?: boolean; // When true, use insecure (plaintext) gRPC even if TLS is detected
+    caCertPath?: string; // PEM bundle of extra CAs to trust (corporate TLS proxies)
     currentContext?: string;
     auth?: {
         type: 'oidc' | 'basic' | 'exec' | 'none';


### PR DESCRIPTION
## Problem

On a network with a TLS-inspecting proxy (Zscaler, Netskope, an internal CA), the certificate the extension receives is re-signed by the proxy. Node.js doesn't ship that CA, so **every** connection fails — and it fails misleadingly:

```
Cannot reach Armada server at https://armada.example.com. Is armada-server running?
```

The server is fine. The real reason (`unable to verify the first certificate`) arrives as a gRPC `UNAVAILABLE` with the OpenSSL text buried in `error.details`, so the surfaced message points at the wrong thing entirely. There was no way to trust an extra CA.

## Fix

Add an `armada.caCertPath` setting pointing at a PEM bundle, honoured by both the gRPC channel and the Lookout HTTPS client. A `caCertPath` on the active armadactl context takes precedence, so per-cluster bundles work.

```jsonc
{ "armada.caCertPath": "~/certs/corporate-ca.pem" }
```

### The bundle is appended to the system roots, not swapped in

Both `grpc.credentials.createSsl(rootCerts)` and `https.Agent`'s `ca` option **replace** the trust store. Passing a corporate bundle through alone would fix the proxied endpoint while silently breaking every publicly-signed one — the same trap as `SSL_CERT_FILE` (replaces) versus `NODE_EXTRA_CA_CERTS` (appends). `withSystemRoots()` concatenates with `tls.rootCertificates`, and a test asserts the combined bundle still holds every system root.

### Errors say what's actually wrong

- Certificate rejections are classified as such instead of "is the server running?".
- Guidance differs depending on whether a bundle is already configured — if one is, it says the bundle likely lacks the signing CA or intermediate chain.
- A bundle that fails to load is **not** treated as in effect, so the user is never told to audit a file that was never read; the load failure is reported on its own, with the reason (`file not found`, `permission denied`) and the path.
- A DER-encoded `.crt` — the most common wrong-format mistake — is rejected with the `openssl x509 -inform der` conversion command rather than an opaque handshake failure.
- An unusable bundle falls back to the default store instead of hard-failing, so a bad setting can't lock you out of a publicly-signed cluster.

### No verification bypass

There is deliberately no "ignore certificate errors" option. The remedy is trusting the right CA, not stopping the check.

## Testing

**84 passing** (was 57 on `main`), verified from a clean clone: `npm ci`, `lint` (0 errors), `typecheck`, `compile`, `test:unit`, and `vsce package` all pass. Confirmed the setting and code land in the built `.vsix`.

The core tests are end-to-end against a **real self-signed TLS server** — a gRPC one for `ArmadaClient` and an HTTPS one for `LookoutClient` — rather than mocks of the TLS layer:

- the same server is unreachable with the default trust store and reachable once its CA is supplied via `caCertPath`
- public CAs still verify when an extra bundle is configured
- the log names a certificate problem, not an unreachable server
- a missing bundle logs the reason and falls back
- an unloadable bundle isn't blamed for the rejection

Certificates are generated per run via `openssl` into a temp dir and are **not** committed: a checked-in private key trips secret scanners and expires. The suites skip themselves when `openssl` is unavailable.

**Negative controls** — each fix was reverted in turn to confirm the tests actually detect it:
- `buildTrustStore` replacing instead of appending roots → exactly the 2 trust-store regression tests failed, other 77 passed
- dropping both unloadable-bundle guards → exactly those 2 tests failed, other 82 passed

## Notes for review

- `MockArmadaServer.start()` takes an optional key/cert pair to serve TLS; the no-arg plaintext behaviour is unchanged.
- README gains a "Corporate networks and TLS-inspecting proxies" section with commands for exporting a PEM bundle on macOS/Linux and converting DER.
- The README's `contexts:` example there uses the keyed-map form the config parser actually reads. The pre-existing Quick Start snippet above it uses a list form that `resolveConfig` does not parse (`contexts` is typed `Record<string, ArmadaContext>`) — left alone as out of scope, but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)