### PR TITLE
fix(submit): accept podSpec and stop dropping job fields silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ contexts:
 
 3. Click the cloud upload icon in the editor or run `Armada: Submit Job`
 
+Each job needs a pod spec with at least one container. Both spellings
+`armadactl` accepts work: `podSpec:` for a single spec, or `podSpecs:` as a list
+for a gang. The pod spec is a standard Kubernetes `PodSpec`, so fields such as
+`priorityClassName`, `securityContext`, `initContainers`, `volumes`,
+`tolerations` and `imagePullSecrets` are all forwarded as written. Any key that
+is not part of `PodSpec` is reported in the **Armada** output channel rather than
+ignored, which catches typos like `imagePullPolcy`.
+
 ### 3. Monitor Jobs
 
 - Open the Armada sidebar (activity bar icon)

--- a/src/commands/submitJob.ts
+++ b/src/commands/submitJob.ts
@@ -4,6 +4,31 @@ import { ArmadaClient } from '../grpc/armadaClient';
 import { ConfigManager } from '../config/configManager';
 import { JobTreeProvider } from '../providers/jobTreeProvider';
 import { ArmadaJobSpec, JobState } from '../types/armada';
+import { readPodSpecs } from '../grpc/podSpecConverter';
+
+/**
+ * Indices of jobs that carry no usable pod spec under either accepted name.
+ *
+ * Exported for tests; the server's own complaint names neither the job nor the
+ * field, so this check is what makes the failure actionable.
+ */
+export function findJobsWithoutPodSpec(jobs: any[]): number[] {
+    const missing: number[] = [];
+    jobs.forEach((job, index) => {
+        if (!job || typeof job !== 'object') {
+            missing.push(index);
+            return;
+        }
+        const specs = readPodSpecs(job);
+        const hasContainers = specs.some(spec =>
+            Array.isArray(spec.containers) && spec.containers.length > 0
+        );
+        if (!hasContainers) {
+            missing.push(index);
+        }
+    });
+    return missing;
+}
 
 export async function submitJobCommand(
     client: ArmadaClient | undefined,
@@ -59,6 +84,19 @@ export async function submitJobCommand(
             return;
         }
 
+        // Catch a missing pod spec here rather than letting the server answer
+        // with a bare "Job must contain at least one PodSpec", which does not
+        // say which job or which field is at fault.
+        const missingPodSpec = findJobsWithoutPodSpec(jobSpec.jobs);
+        if (missingPodSpec.length > 0) {
+            const list = missingPodSpec.map(index => `jobs[${index}]`).join(', ');
+            vscode.window.showErrorMessage(
+                `No pod spec found for ${list}. Each job needs a "podSpec" (or "podSpecs") ` +
+                'containing at least one container.'
+            );
+            return;
+        }
+
         // Confirm submission (unless skipConfirmation is set)
         const jobCount = jobSpec.jobs.length;
         if (!options?.skipConfirmation) {
@@ -84,18 +122,9 @@ export async function submitJobCommand(
                 try {
                     const response = await client.submitJobs(jobSpec);
 
-                    // Add each submitted job to the tree view
-                    for (const jobResponse of response.jobIds) {
-                        let jobId: string;
-
-                        if (typeof jobResponse === 'string') {
-                            jobId = jobResponse;
-                        } else if (typeof jobResponse === 'object' && jobResponse !== null) {
-                            jobId = (jobResponse as any).job_id || (jobResponse as any).jobId || String(jobResponse);
-                        } else {
-                            jobId = String(jobResponse);
-                        }
-
+                    // Only accepted jobs go in the tree. Adding rejected ones
+                    // created entries that could never resolve.
+                    for (const jobId of response.jobIds) {
                         jobTreeProvider.addJob({
                             jobId: jobId,
                             jobSetId: jobSpec.jobSetId,
@@ -105,9 +134,27 @@ export async function submitJobCommand(
                         });
                     }
 
-                    vscode.window.showInformationMessage(
-                        `Successfully submitted ${response.jobIds.length} job${response.jobIds.length > 1 ? 's' : ''} to Armada!`
-                    );
+                    const accepted = response.jobIds.length;
+                    const rejected = response.rejected;
+
+                    if (rejected.length === 0) {
+                        vscode.window.showInformationMessage(
+                            `Successfully submitted ${accepted} job${accepted === 1 ? '' : 's'} to Armada!`
+                        );
+                    } else {
+                        // A partial success used to be reported as a total one.
+                        const reasons = rejected
+                            .map(failure => `jobs[${failure.index}]: ${failure.error}`)
+                            .join('; ');
+                        const detail = `${rejected.length} of ${accepted + rejected.length} job(s) rejected by Armada — ${reasons}`;
+                        if (accepted === 0) {
+                            vscode.window.showErrorMessage(detail);
+                        } else {
+                            vscode.window.showWarningMessage(
+                                `Submitted ${accepted} job${accepted === 1 ? '' : 's'}, but ${detail}`
+                            );
+                        }
+                    }
 
                 } catch (error: any) {
                     throw error;

--- a/src/grpc/armadaClient.ts
+++ b/src/grpc/armadaClient.ts
@@ -3,9 +3,11 @@ import * as protoLoader from '@grpc/proto-loader';
 import * as path from 'path';
 import * as tls from 'tls';
 import { ResolvedConfig } from '../types/config';
-import { ArmadaJobSpec, SubmitJobResponse, JobEventMessage, Queue, ConnectionState, ConnectionTestResult } from '../types/armada';
+import { ArmadaJobSpec, SubmitJobResponse, JobEventMessage, Queue, ConnectionState, ConnectionTestResult, RejectedJob } from '../types/armada';
+import * as protobuf from 'protobufjs';
 import { buildAuthHeader, isSecureCredentials, makeAuthInterceptor, withCallCredentials } from './auth';
 import { buildTrustStore, countCertificates, describeCertificateError, resolveCertPath } from './caCerts';
+import { ConversionReport, convertJobItem } from './podSpecConverter';
 
 /**
  * Strip any `http://` or `https://` scheme prefix from a URL so that the
@@ -49,6 +51,36 @@ export function selectCredentials(
         // Node's bundled root store, so without this the handshake fails.
         ? grpc.credentials.createSsl(rootCerts)
         : grpc.credentials.createInsecure();
+}
+
+/**
+ * Message descriptors used to convert YAML into the exact shape the vendored
+ * protos expect.
+ *
+ * @grpc/proto-loader exposes only serialize/deserialize for message types, not
+ * the protobufjs `Type` needed to walk fields, so the descriptors are loaded
+ * separately. Parsed once and cached: the k8s protos are large and the result is
+ * immutable.
+ */
+let submitTypes: { podSpec: protobuf.Type; jobItem: protobuf.Type } | undefined;
+
+export function getSubmitTypes(): { podSpec: protobuf.Type; jobItem: protobuf.Type } {
+    if (submitTypes) {
+        return submitTypes;
+    }
+    const protoRoot = path.join(__dirname, 'proto');
+    const root = new protobuf.Root();
+    // Resolve imports against the bundled proto tree, mirroring the
+    // `includeDirs` given to proto-loader.
+    root.resolvePath = (_origin, target) => path.resolve(protoRoot, target);
+    // keepCase matches the proto-loader options, so field names stay as the
+    // proto declares them (`priorityClassName`, not `priority_class_name`).
+    root.loadSync('pkg/api/submit.proto', { keepCase: true });
+    submitTypes = {
+        podSpec: root.lookupType('k8s.io.api.core.v1.PodSpec'),
+        jobItem: root.lookupType('api.JobSubmitRequestItem')
+    };
+    return submitTypes;
 }
 
 export class ArmadaClient {
@@ -440,7 +472,7 @@ export class ArmadaClient {
     async submitJobs(jobSpec: ArmadaJobSpec): Promise<SubmitJobResponse> {
         this.initializeClients();
         return new Promise((resolve, reject) => {
-            const jobRequestItems = jobSpec.jobs.map(job => this.convertJobToProto(job));
+            const jobRequestItems = jobSpec.jobs.map((job, index) => this.convertJobToProto(job, index));
 
             // Debug logging
             console.log('[Armada] Submitting jobs:', JSON.stringify({
@@ -466,9 +498,34 @@ export class ArmadaClient {
 
                 this.updateConnectionState('connected');
                 console.log('[Armada] Submit successful:', response);
-                resolve({
-                    jobIds: response.job_response_items || []
+
+                // The server reports per-item failures inside a successful call,
+                // so a response is not proof every job was accepted.
+                const items: any[] = response.job_response_items || [];
+                const jobIds: string[] = [];
+                const rejected: RejectedJob[] = [];
+
+                items.forEach((item, index) => {
+                    const error = typeof item?.error === 'string' ? item.error.trim() : '';
+                    if (error) {
+                        rejected.push({ index, error });
+                        return;
+                    }
+                    const jobId = item?.job_id || item?.jobId;
+                    if (jobId) {
+                        jobIds.push(String(jobId));
+                    } else {
+                        // Neither an id nor a reason: still a failure, and
+                        // reporting it beats inventing a job that does not exist.
+                        rejected.push({ index, error: 'server returned no job id' });
+                    }
                 });
+
+                for (const failure of rejected) {
+                    this.logError(`Armada rejected jobs[${failure.index}]: ${failure.error}`);
+                }
+
+                resolve({ jobIds, rejected });
             });
         });
     }
@@ -681,93 +738,26 @@ export class ArmadaClient {
     /**
      * Convert job spec to protobuf format
      */
-    private convertJobToProto(job: any): any {
-        console.log('[Armada] Converting job to proto:', JSON.stringify(job, null, 2));
+    private convertJobToProto(job: any, jobIndex = 0): any {
+        const report: ConversionReport = { unknownFields: [] };
+        const { podSpec, jobItem } = getSubmitTypes();
 
-        // Convert podSpecs to Kubernetes PodSpec format
-        const podSpecs = job.podSpecs ? job.podSpecs.map((spec: any) => {
-            console.log('[Armada] Processing podSpec:', JSON.stringify(spec, null, 2));
+        // Walks the descriptor rather than an allowlist, and accepts both the
+        // singular `podSpec:` and the plural `podSpecs:` forms. Reading only the
+        // plural made most real job files — and this extension's own README
+        // example — submit an empty pod_specs, which the server rejects with
+        // "Job must contain at least one PodSpec".
+        const result = convertJobItem(job, jobItem, podSpec, report, `jobs[${jobIndex}]`);
 
-            // Convert containers with proper resource format
-            const containers = (spec.containers || []).map((container: any) => {
-                const convertedContainer: any = {
-                    name: container.name,
-                    image: container.image,
-                    command: container.command,
-                    args: container.args,
-                    imagePullPolicy: container.imagePullPolicy
-                };
+        // A typo'd or unsupported key would otherwise vanish without trace: the
+        // job submits and then behaves differently than the file describes.
+        if (report.unknownFields.length > 0) {
+            this.logWarning(
+                `Ignoring ${report.unknownFields.length} unrecognized field(s) in the job file: ` +
+                `${report.unknownFields.join(', ')}. Check for typos — these are not sent to Armada.`
+            );
+        }
 
-                // Convert resources to Kubernetes Quantity format
-                if (container.resources) {
-                    convertedContainer.resources = {};
-
-                    if (container.resources.limits) {
-                        convertedContainer.resources.limits = {};
-                        for (const [key, value] of Object.entries(container.resources.limits)) {
-                            convertedContainer.resources.limits[key] = { string: String(value) };
-                        }
-                    }
-
-                    if (container.resources.requests) {
-                        convertedContainer.resources.requests = {};
-                        for (const [key, value] of Object.entries(container.resources.requests)) {
-                            convertedContainer.resources.requests[key] = { string: String(value) };
-                        }
-                    }
-                }
-
-                // Add other optional container fields
-                if (container.env) convertedContainer.env = container.env;
-                if (container.volumeMounts) convertedContainer.volumeMounts = container.volumeMounts;
-                if (container.ports) convertedContainer.ports = container.ports;
-                if (container.securityContext) convertedContainer.securityContext = container.securityContext;
-
-                return convertedContainer;
-            });
-
-            const podSpec: any = {
-                containers: containers,
-                restartPolicy: spec.restartPolicy || 'Never'
-            };
-
-            // Add optional fields if present
-            if (spec.terminationGracePeriodSeconds !== undefined) {
-                podSpec.terminationGracePeriodSeconds = spec.terminationGracePeriodSeconds;
-            }
-            if (spec.activeDeadlineSeconds !== undefined) {
-                podSpec.activeDeadlineSeconds = spec.activeDeadlineSeconds;
-            }
-            if (spec.nodeSelector) {
-                podSpec.nodeSelector = spec.nodeSelector;
-            }
-            if (spec.tolerations) {
-                podSpec.tolerations = spec.tolerations;
-            }
-            if (spec.affinity) {
-                podSpec.affinity = spec.affinity;
-            }
-            if (spec.volumes) {
-                podSpec.volumes = spec.volumes;
-            }
-            if (spec.imagePullSecrets) {
-                podSpec.imagePullSecrets = spec.imagePullSecrets;
-            }
-
-            console.log('[Armada] Converted podSpec:', JSON.stringify(podSpec, null, 2));
-            return podSpec;
-        }) : [];
-
-        const result = {
-            priority: job.priority || 0,
-            namespace: job.namespace || 'default',
-            client_id: job.clientId || '',
-            labels: job.labels || {},
-            annotations: job.annotations || {},
-            pod_specs: podSpecs
-        };
-
-        console.log('[Armada] Final proto job:', JSON.stringify(result, null, 2));
         return result;
     }
 

--- a/src/grpc/podSpecConverter.ts
+++ b/src/grpc/podSpecConverter.ts
@@ -1,0 +1,313 @@
+import type { Type, Field } from 'protobufjs';
+
+/**
+ * Convert Kubernetes YAML into the shape the vendored Armada protos expect.
+ *
+ * The previous implementation hand-copied an allowlist of nine PodSpec fields
+ * and ten Container fields, so everything else a user wrote was dropped
+ * silently: `priorityClassName`, pod-level `securityContext`, `initContainers`,
+ * container `lifecycle` and the rest never reached the server, and the job ran
+ * with different semantics than the file described.
+ *
+ * This walks the loaded protobuf descriptor instead, so every field the proto
+ * knows about is forwarded and new ones work without code changes. Only the
+ * places where the vendored gogo protos genuinely differ from Kubernetes YAML
+ * are reshaped:
+ *
+ *   1. Embedded structs. gogoproto's `(gogoproto.embed)` option is not applied
+ *      to the generated `.proto`, so `Volume.volumeSource`,
+ *      `SecretKeySelector.localObjectReference` and friends appear as real
+ *      nested messages. Kubernetes YAML writes their contents flat
+ *      (`persistentVolumeClaim:` directly on the volume, `name:` directly on
+ *      the secret ref), so those keys have to be lifted into the wrapper.
+ *      Without this a PVC volume encodes to nothing but its name — and an empty
+ *      VolumeSource means EmptyDir, so the mount silently becomes scratch space.
+ *
+ *   2. Quantity. `resource.Quantity` is a message with a single `string` field,
+ *      so `memory: 5Gi` (or an unquoted `cpu: 16`) has to become
+ *      `{ string: '5Gi' }`. This applies anywhere a Quantity appears, not just
+ *      under `resources` — `emptyDir.sizeLimit` is one too.
+ *
+ *   3. IntOrString. Ports and probe targets accept either form.
+ *
+ * Anything the descriptor does not recognise is reported to `onUnknownField`
+ * rather than dropped in silence, so a typo like `imagePullPolcy` is visible.
+ */
+
+/** Fully-qualified names of the scalar-shaped wrapper messages. */
+const QUANTITY_TYPE = 'k8s.io.apimachinery.pkg.api.resource.Quantity';
+const INT_OR_STRING_TYPE = 'k8s.io.apimachinery.pkg.util.intstr.IntOrString';
+
+/**
+ * Wrapper fields whose contents Kubernetes YAML writes flat on the parent.
+ *
+ * Detected structurally rather than hard-coded by name: a single message-typed
+ * field is treated as embedded when the YAML key is absent and the parent has
+ * keys that only the wrapper's type declares. Keeping the known names as a hint
+ * makes the intent explicit and the behaviour predictable.
+ */
+const EMBEDDED_FIELD_NAMES = new Set([
+    'volumeSource',
+    'localObjectReference',
+    'handler'
+]);
+
+export interface ConversionReport {
+    /** Dotted paths of keys the descriptor does not declare. */
+    unknownFields: string[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Kubernetes accepts unquoted numeric quantities (`cpu: 16`, `memory: 5Gi`).
+ * The proto wants the string form in a wrapper message.
+ */
+function toQuantity(value: unknown): unknown {
+    if (isPlainObject(value) && 'string' in value) {
+        return value; // already wrapped
+    }
+    return { string: String(value) };
+}
+
+function toIntOrString(value: unknown): unknown {
+    if (isPlainObject(value)) {
+        return value;
+    }
+    // type 0 = Int, 1 = String, matching intstr.IntOrString.
+    return typeof value === 'number'
+        ? { type: 0, intVal: value }
+        : { type: 1, strVal: String(value) };
+}
+
+/**
+ * Look up a field by its YAML key, accepting either casing.
+ *
+ * The Kubernetes protos declare camelCase field names, but Armada's own messages
+ * use snake_case (`client_id`, `tls_enabled`) while users write the camelCase
+ * form that armadactl and the JSON API accept. Converting the key rather than
+ * maintaining an alias table means new fields need no code change.
+ */
+function findField(messageType: Type, key: string): Field | undefined {
+    const direct = messageType.fields[key];
+    if (direct) {
+        return direct;
+    }
+    const snake = key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+    return snake === key ? undefined : messageType.fields[snake];
+}
+
+/**
+ * Find the embedded wrapper field, if any, that declares `key`.
+ *
+ * Returns the wrapper field name so the caller can nest the value under it.
+ */
+function findEmbeddedHost(messageType: Type, key: string): Field | undefined {
+    for (const field of messageType.fieldsArray) {
+        if (!EMBEDDED_FIELD_NAMES.has(field.name)) {
+            continue;
+        }
+        field.resolve();
+        const inner = field.resolvedType as Type | null;
+        if (inner && typeof inner.fieldsArray !== 'undefined' && findField(inner, key)) {
+            return field;
+        }
+    }
+    return undefined;
+}
+
+function convertValue(
+    value: unknown,
+    field: Field,
+    path: string,
+    report: ConversionReport
+): unknown {
+    field.resolve();
+
+    if (field.map) {
+        // Map values still need per-value conversion (resources.limits is a
+        // map<string, Quantity>).
+        if (!isPlainObject(value)) {
+            return value;
+        }
+        const out: Record<string, unknown> = {};
+        for (const [key, entry] of Object.entries(value)) {
+            out[key] = convertLeaf(entry, field, `${path}.${key}`, report);
+        }
+        return out;
+    }
+
+    if (field.repeated) {
+        if (!Array.isArray(value)) {
+            // Let the caller's validation surface the shape error; forwarding it
+            // unchanged keeps the proto layer's own message intact.
+            return value;
+        }
+        return value.map((entry, index) => convertLeaf(entry, field, `${path}[${index}]`, report));
+    }
+
+    return convertLeaf(value, field, path, report);
+}
+
+function convertLeaf(
+    value: unknown,
+    field: Field,
+    path: string,
+    report: ConversionReport
+): unknown {
+    const typeName = field.resolvedType?.fullName?.replace(/^\./, '');
+
+    if (typeName === QUANTITY_TYPE) {
+        return toQuantity(value);
+    }
+    if (typeName === INT_OR_STRING_TYPE) {
+        return toIntOrString(value);
+    }
+
+    const messageType = field.resolvedType as Type | undefined;
+    if (messageType && typeof messageType.fieldsArray !== 'undefined' && isPlainObject(value)) {
+        return convertMessage(value, messageType, path, report);
+    }
+
+    return value;
+}
+
+/**
+ * Convert one YAML mapping into the descriptor's shape, recursively.
+ */
+export function convertMessage(
+    source: Record<string, unknown>,
+    messageType: Type,
+    path: string,
+    report: ConversionReport
+): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(source)) {
+        if (value === undefined) {
+            continue;
+        }
+        const childPath = path ? `${path}.${key}` : key;
+
+        const field = findField(messageType, key);
+        if (field) {
+            out[field.name] = convertValue(value, field, childPath, report);
+            continue;
+        }
+
+        // Not a direct field: it may belong to an embedded wrapper that
+        // Kubernetes YAML writes flat (volumeSource, localObjectReference).
+        const host = findEmbeddedHost(messageType, key);
+        if (host) {
+            host.resolve();
+            const hostType = host.resolvedType as Type;
+            const nested = (out[host.name] as Record<string, unknown>) ?? {};
+            const hostField = findField(hostType, key) as Field;
+            nested[hostField.name] = convertValue(value, hostField, childPath, report);
+            out[host.name] = nested;
+            continue;
+        }
+
+        report.unknownFields.push(childPath);
+    }
+
+    return out;
+}
+
+/**
+ * Convert a Kubernetes PodSpec written as YAML into the vendored proto shape.
+ */
+export function convertPodSpec(
+    spec: Record<string, unknown>,
+    podSpecType: Type,
+    report: ConversionReport,
+    path = 'podSpec'
+): Record<string, unknown> {
+    const converted = convertMessage(spec, podSpecType, path, report);
+    // Armada rejects a pod with no restartPolicy; Never is the only sensible
+    // default for a batch job and matches the previous behaviour.
+    if (converted.restartPolicy === undefined) {
+        converted.restartPolicy = 'Never';
+    }
+    return converted;
+}
+
+/**
+ * Read the pod specs from a job, accepting both forms armadactl accepts.
+ *
+ * The proto carries a deprecated singular `pod_spec` (field 2) alongside the
+ * repeated `pod_specs` (field 7), and armadactl reconciles them with
+ * GetMainPodSpec. Users — and this extension's own README — overwhelmingly
+ * write the singular `podSpec:`, so accepting only the plural form made most
+ * real job files unsubmittable. Both are normalized into the repeated field:
+ * that is wire-equivalent for a single spec and avoids emitting a deprecated
+ * field, and sending both risks the server reading one as the main spec and the
+ * other as an extra gang member.
+ */
+/** Keys handled by readPodSpecs rather than by descriptor lookup. */
+const POD_SPEC_KEYS = new Set(['podSpec', 'podSpecs', 'pod_spec', 'pod_specs']);
+
+/**
+ * Convert one entry of a job file's `jobs:` list into a JobSubmitRequestItem.
+ *
+ * Job-level fields were hand-copied too, so `ingress`, `services` and
+ * `scheduler` never reached the server despite being documented in the
+ * extension's own types.
+ */
+export function convertJobItem(
+    job: Record<string, unknown>,
+    itemType: Type,
+    podSpecType: Type,
+    report: ConversionReport,
+    path: string
+): Record<string, unknown> {
+    const out: Record<string, unknown> = {
+        priority: 0,
+        namespace: 'default',
+        client_id: '',
+        labels: {},
+        annotations: {}
+    };
+
+    for (const [key, value] of Object.entries(job)) {
+        if (value === undefined || POD_SPEC_KEYS.has(key)) {
+            continue;
+        }
+        const field = findField(itemType, key);
+        if (!field) {
+            report.unknownFields.push(`${path}.${key}`);
+            continue;
+        }
+        out[field.name] = convertValue(value, field, `${path}.${key}`, report);
+    }
+
+    out.pod_specs = readPodSpecs(job).map((spec, index) =>
+        convertPodSpec(spec, podSpecType, report, `${path}.podSpec[${index}]`)
+    );
+
+    return out;
+}
+
+export function readPodSpecs(job: Record<string, unknown>): Record<string, unknown>[] {
+    const plural = job.podSpecs;
+    const singular = job.podSpec;
+
+    const specs: unknown[] = [];
+    if (Array.isArray(plural)) {
+        specs.push(...plural);
+    } else if (isPlainObject(plural)) {
+        // A bare mapping under the plural key: the mistake the old schema's
+        // "required: podSpecs" message invited. Previously an unhandled
+        // `job.podSpecs.map is not a function`.
+        specs.push(plural);
+    }
+    if (isPlainObject(singular)) {
+        specs.push(singular);
+    } else if (Array.isArray(singular)) {
+        specs.push(...singular);
+    }
+
+    return specs.filter(isPlainObject);
+}

--- a/src/test/mock/armadaServer.ts
+++ b/src/test/mock/armadaServer.ts
@@ -20,11 +20,17 @@ function loadProto(protoFile: string): grpc.GrpcObject {
     return grpc.loadPackageDefinition(def);
 }
 
+/** Jobs submitted to this namespace are rejected per item, for testing. */
+export const REJECT_NAMESPACE = 'reject-me';
+
 export class MockArmadaServer {
     private server: grpc.Server;
     private port: number = 0;
     /** Metadata from the most recent call, so tests can assert on auth headers. */
     private lastMetadata: grpc.Metadata | undefined;
+    /** The most recent SubmitJobs request, so tests can assert what went on the wire. */
+    private lastSubmitRequest: any;
+    private submitCallCount: number = 0;
 
     constructor() {
         this.server = new grpc.Server();
@@ -40,6 +46,30 @@ export class MockArmadaServer {
     /** Forget any recorded metadata, so a test starts from a known state. */
     resetLastMetadata(): void {
         this.lastMetadata = undefined;
+    }
+
+    /**
+     * The decoded SubmitJobs request from the most recent call.
+     *
+     * This is what actually crossed the wire, so assertions on it catch fields
+     * the client drops or mis-shapes during conversion.
+     */
+    getLastSubmitRequest(): any {
+        return this.lastSubmitRequest;
+    }
+
+    /** The first pod spec of the given job in the most recent submission. */
+    getSubmittedPodSpec(jobIndex = 0, specIndex = 0): any {
+        return this.lastSubmitRequest?.job_request_items?.[jobIndex]?.pod_specs?.[specIndex];
+    }
+
+    getSubmitCallCount(): number {
+        return this.submitCallCount;
+    }
+
+    resetSubmitCalls(): void {
+        this.lastSubmitRequest = undefined;
+        this.submitCallCount = 0;
     }
 
     private recordMetadata(call: any): void {
@@ -94,11 +124,21 @@ export class MockArmadaServer {
     // Submit handlers
     private handleSubmitJobs(call: any, callback: any): void {
         this.recordMetadata(call);
+        this.lastSubmitRequest = call.request;
+        this.submitCallCount += 1;
         const jobs: any[] = call.request.job_request_items || [];
-        const items = jobs.map(() => ({
-            job_id: crypto.randomUUID(),
-            error: ''
-        }));
+
+        // Reject items the way a real server does — per item, inside an
+        // otherwise successful call — so tests can cover partial failure.
+        const items = jobs.map((job: any) => {
+            if (!job.pod_specs || job.pod_specs.length === 0) {
+                return { job_id: '', error: 'Job must contain at least one PodSpec' };
+            }
+            if (job.namespace === REJECT_NAMESPACE) {
+                return { job_id: '', error: `namespace "${REJECT_NAMESPACE}" is not permitted for this user` };
+            }
+            return { job_id: crypto.randomUUID(), error: '' };
+        });
         callback(null, { job_response_items: items });
     }
 

--- a/src/test/unit/commands/submitJob.test.ts
+++ b/src/test/unit/commands/submitJob.test.ts
@@ -1,0 +1,231 @@
+import * as assert from 'assert';
+import { installVscodeMock, vscodeMock } from '../vscodeMock';
+
+const shownInfo: string[] = [];
+const shownWarnings: string[] = [];
+const shownErrors: string[] = [];
+
+installVscodeMock();
+
+/**
+ * The vscode mock is shared and other suites replace these spies at module load,
+ * so install ours per test and put the originals back afterwards.
+ */
+function installSpies(): void {
+    (vscodeMock.window as any).showInformationMessage = async (msg: string, ...actions: string[]) => {
+        shownInfo.push(msg);
+        // Auto-confirm the submission prompt; plain notifications take no action.
+        return actions.includes('Submit') ? 'Submit' : undefined;
+    };
+    (vscodeMock.window as any).showWarningMessage = async (msg: string) => { shownWarnings.push(msg); return undefined; };
+    (vscodeMock.window as any).showErrorMessage = async (msg: string) => { shownErrors.push(msg); return undefined; };
+}
+
+// Import AFTER the mock is in place.
+const { submitJobCommand, findJobsWithoutPodSpec } = require('../../../commands/submitJob');
+
+function setActiveYaml(content: string): void {
+    (vscodeMock.window as any).activeTextEditor = {
+        document: {
+            languageId: 'yaml',
+            fileName: '/tmp/job.yml',
+            getText: () => content
+        }
+    };
+}
+
+function makeClient(response: any, error?: Error) {
+    const calls: any[] = [];
+    return {
+        calls,
+        submitJobs: async (spec: any) => {
+            calls.push(spec);
+            if (error) { throw error; }
+            return response;
+        }
+    };
+}
+
+function makeTree() {
+    const added: any[] = [];
+    return { added, addJob: (job: any) => added.push(job) };
+}
+
+const CONFIG_MANAGER = {} as any;
+
+describe('findJobsWithoutPodSpec', () => {
+    const containers = [{ name: 'c', image: 'busybox' }];
+
+    it('accepts the singular podSpec form', () => {
+        assert.deepStrictEqual(findJobsWithoutPodSpec([{ podSpec: { containers } }]), []);
+    });
+
+    it('accepts the plural list form', () => {
+        assert.deepStrictEqual(findJobsWithoutPodSpec([{ podSpecs: [{ containers }] }]), []);
+    });
+
+    it('accepts a bare mapping under the plural key', () => {
+        assert.deepStrictEqual(findJobsWithoutPodSpec([{ podSpecs: { containers } }]), []);
+    });
+
+    it('flags a job with no pod spec at all', () => {
+        assert.deepStrictEqual(findJobsWithoutPodSpec([{ namespace: 'apqx' }]), [0]);
+    });
+
+    it('flags a pod spec with no containers', () => {
+        assert.deepStrictEqual(findJobsWithoutPodSpec([{ podSpec: { restartPolicy: 'Never' } }]), [0]);
+        assert.deepStrictEqual(findJobsWithoutPodSpec([{ podSpec: { containers: [] } }]), [0]);
+    });
+
+    it('reports only the offending indices', () => {
+        assert.deepStrictEqual(
+            findJobsWithoutPodSpec([
+                { podSpec: { containers } },
+                { namespace: 'apqx' },
+                { podSpecs: [{ containers }] },
+                null
+            ]),
+            [1, 3]
+        );
+    });
+});
+
+describe('submitJobCommand', () => {
+    let originalWindow: Record<string, unknown>;
+
+    beforeEach(() => {
+        shownInfo.length = 0;
+        shownWarnings.length = 0;
+        shownErrors.length = 0;
+        // Snapshot per test, not at load: other suites install their own spies
+        // while files are being loaded, and restoring a load-time snapshot would
+        // wipe them.
+        originalWindow = { ...(vscodeMock.window as any) };
+        installSpies();
+    });
+
+    afterEach(() => {
+        Object.assign(vscodeMock.window as any, originalWindow);
+    });
+
+    const VALID_YAML = `
+queue: apqx
+jobSetId: js-1
+jobs:
+  - namespace: apqx
+    podSpec:
+      containers:
+        - name: c
+          image: busybox
+`;
+
+    it('submits a valid file and reports success', async () => {
+        setActiveYaml(VALID_YAML);
+        const client = makeClient({ jobIds: ['job-1'], rejected: [] });
+        const tree = makeTree();
+
+        await submitJobCommand(client, CONFIG_MANAGER, tree);
+
+        assert.strictEqual(client.calls.length, 1);
+        assert.strictEqual(tree.added.length, 1);
+        assert.strictEqual(tree.added[0].jobId, 'job-1');
+        assert.deepStrictEqual(shownErrors, []);
+        assert.ok(
+            shownInfo.some(m => /Successfully submitted 1 job to Armada/.test(m)),
+            `expected a singular success message, got: ${shownInfo.join(' | ')}`
+        );
+    });
+
+    it('refuses to submit a job with no pod spec, naming the job and the field', async () => {
+        // Without this the server answers "Job must contain at least one PodSpec",
+        // which names neither the job nor the key to fix.
+        setActiveYaml(`
+queue: apqx
+jobSetId: js-1
+jobs:
+  - namespace: apqx
+    containers:
+      - name: c
+        image: busybox
+`);
+        const client = makeClient({ jobIds: [], rejected: [] });
+
+        await submitJobCommand(client, CONFIG_MANAGER, makeTree());
+
+        assert.strictEqual(client.calls.length, 0, 'must not reach the server');
+        assert.strictEqual(shownErrors.length, 1);
+        assert.match(shownErrors[0], /jobs\[0\]/);
+        assert.match(shownErrors[0], /podSpec/);
+    });
+
+    it('names every offending job when several lack pod specs', async () => {
+        setActiveYaml(`
+queue: apqx
+jobSetId: js-1
+jobs:
+  - namespace: apqx
+  - namespace: apqx
+    podSpec:
+      containers:
+        - name: c
+          image: busybox
+  - namespace: apqx
+    podSpec: {}
+`);
+        const client = makeClient({ jobIds: [], rejected: [] });
+
+        await submitJobCommand(client, CONFIG_MANAGER, makeTree());
+
+        assert.strictEqual(client.calls.length, 0);
+        assert.match(shownErrors[0], /jobs\[0\], jobs\[2\]/);
+    });
+
+    it('warns on a partial rejection instead of claiming full success', async () => {
+        setActiveYaml(VALID_YAML);
+        const client = makeClient({
+            jobIds: ['job-1'],
+            rejected: [{ index: 1, error: 'namespace "nope" is not permitted for this user' }]
+        });
+        const tree = makeTree();
+
+        await submitJobCommand(client, CONFIG_MANAGER, tree);
+
+        assert.deepStrictEqual(shownErrors, []);
+        assert.strictEqual(shownWarnings.length, 1, `expected one warning, got ${shownWarnings.join(' | ')}`);
+        assert.match(shownWarnings[0], /jobs\[1\]/);
+        assert.match(shownWarnings[0], /not permitted/);
+        assert.ok(
+            !shownInfo.some(m => /Successfully submitted/.test(m)),
+            'a partial failure must not be reported as a success'
+        );
+        // Only the accepted job belongs in the tree; a rejected one never resolves.
+        assert.strictEqual(tree.added.length, 1);
+        assert.strictEqual(tree.added[0].jobId, 'job-1');
+    });
+
+    it('errors and adds nothing when every job is rejected', async () => {
+        setActiveYaml(VALID_YAML);
+        const client = makeClient({
+            jobIds: [],
+            rejected: [{ index: 0, error: 'Job must contain at least one PodSpec' }]
+        });
+        const tree = makeTree();
+
+        await submitJobCommand(client, CONFIG_MANAGER, tree);
+
+        assert.strictEqual(shownErrors.length, 1);
+        assert.match(shownErrors[0], /rejected by Armada/);
+        assert.strictEqual(tree.added.length, 0);
+        assert.strictEqual(shownWarnings.length, 0);
+    });
+
+    it('surfaces a call-level failure', async () => {
+        setActiveYaml(VALID_YAML);
+        const client = makeClient(undefined, new Error('UNAVAILABLE from localhost:50051'));
+
+        await submitJobCommand(client, CONFIG_MANAGER, makeTree());
+
+        assert.strictEqual(shownErrors.length, 1);
+        assert.match(shownErrors[0], /UNAVAILABLE/);
+    });
+});

--- a/src/test/unit/grpc/convertJob.test.ts
+++ b/src/test/unit/grpc/convertJob.test.ts
@@ -1,0 +1,454 @@
+import * as assert from 'assert';
+import { MockArmadaServer, REJECT_NAMESPACE } from '../../mock/armadaServer';
+import { ArmadaClient } from '../../../grpc/armadaClient';
+import { ArmadaJobSpec } from '../../../types/armada';
+
+/**
+ * These assert on what actually crossed the wire, decoded by the server, rather
+ * than on the client's intermediate objects. A field that the client builds but
+ * the proto silently discards — the failure mode behind the dropped PVC claim —
+ * is only visible from this side.
+ */
+describe('job submission conversion', function () {
+    let server: MockArmadaServer;
+    let client: ArmadaClient;
+    let logs: string[];
+
+    before(async function () {
+        server = new MockArmadaServer();
+        const port = await server.start();
+        client = new ArmadaClient({ armadaUrl: `localhost:${port}`, auth: { type: 'none' } });
+        logs = [];
+        client.onLogMessage = (message) => logs.push(message);
+    });
+
+    after(async function () {
+        await server.stop();
+    });
+
+    beforeEach(function () {
+        server.resetSubmitCalls();
+        logs.length = 0;
+    });
+
+    const container = { name: 'c', image: 'busybox', resources: {} };
+
+    function spec(jobs: any[]): ArmadaJobSpec {
+        return { queue: 'q', jobSetId: 'js', jobs } as ArmadaJobSpec;
+    }
+
+    describe('podSpec / podSpecs forms', () => {
+        it('accepts the singular podSpec form armadactl uses', async () => {
+            // The form in the extension's own README and in most real job files.
+            // Reading only the plural key sent an empty pod_specs, which the
+            // server rejects outright.
+            const response = await client.submitJobs(spec([
+                { namespace: 'apqx', podSpec: { containers: [container] } }
+            ]));
+
+            assert.strictEqual(response.rejected.length, 0, JSON.stringify(response.rejected));
+            assert.strictEqual(response.jobIds.length, 1);
+            const item = server.getLastSubmitRequest().job_request_items[0];
+            assert.strictEqual(item.pod_specs.length, 1);
+            assert.strictEqual(item.pod_specs[0].containers[0].image, 'busybox');
+        });
+
+        it('accepts the plural podSpecs list form', async () => {
+            const response = await client.submitJobs(spec([
+                { namespace: 'apqx', podSpecs: [{ containers: [container] }] }
+            ]));
+
+            assert.strictEqual(response.rejected.length, 0);
+            assert.strictEqual(server.getSubmittedPodSpec().containers.length, 1);
+        });
+
+        it('accepts a bare mapping under the plural key without crashing', async () => {
+            // Renaming podSpec -> podSpecs without also making it a list is the
+            // exact mistake the old schema error invited; it used to throw
+            // "job.podSpecs.map is not a function".
+            const response = await client.submitJobs(spec([
+                { namespace: 'apqx', podSpecs: { containers: [container] } }
+            ]));
+
+            assert.strictEqual(response.rejected.length, 0);
+            assert.strictEqual(server.getSubmittedPodSpec().containers.length, 1);
+        });
+
+        it('never sends both pod_spec and pod_specs', async () => {
+            // Populating both risks the server treating one as the main spec and
+            // the other as an extra gang member.
+            await client.submitJobs(spec([
+                { namespace: 'apqx', podSpec: { containers: [container] } }
+            ]));
+
+            const item = server.getLastSubmitRequest().job_request_items[0];
+            assert.strictEqual(item.pod_specs.length, 1);
+            assert.ok(
+                item.pod_spec === null || item.pod_spec === undefined,
+                `deprecated singular field should stay unset, got ${JSON.stringify(item.pod_spec)}`
+            );
+        });
+
+        it('sends every spec when both forms appear', async () => {
+            await client.submitJobs(spec([
+                {
+                    namespace: 'apqx',
+                    podSpec: { containers: [container] },
+                    podSpecs: [{ containers: [container] }]
+                }
+            ]));
+
+            assert.strictEqual(server.getLastSubmitRequest().job_request_items[0].pod_specs.length, 2);
+        });
+    });
+
+    describe('pod-level fields', () => {
+        it('preserves the scheduling and security fields the allowlist used to drop', async () => {
+            // Each of these was silently discarded: the job submitted fine and
+            // then ran with different semantics than the file described.
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                podSpec: {
+                    priorityClassName: 'armada-default',
+                    securityContext: { fsGroup: 7005, supplementalGroups: [9000] },
+                    serviceAccountName: 'runner',
+                    schedulerName: 'default-scheduler',
+                    activeDeadlineSeconds: 259200,
+                    terminationGracePeriodSeconds: 0,
+                    nodeSelector: { platform: 'diva' },
+                    tolerations: [{ key: 'platform', operator: 'Equal', value: 'diva', effect: 'NoSchedule' }],
+                    imagePullSecrets: [{ name: 'apqxdls-acr-credentials' }],
+                    containers: [container]
+                }
+            }]));
+
+            const sent = server.getSubmittedPodSpec();
+            assert.strictEqual(sent.priorityClassName, 'armada-default');
+            assert.strictEqual(String(sent.securityContext.fsGroup), '7005');
+            assert.deepStrictEqual(sent.securityContext.supplementalGroups.map(String), ['9000']);
+            assert.strictEqual(sent.serviceAccountName, 'runner');
+            assert.strictEqual(sent.schedulerName, 'default-scheduler');
+            assert.strictEqual(String(sent.activeDeadlineSeconds), '259200');
+            assert.deepStrictEqual(sent.nodeSelector, { platform: 'diva' });
+            assert.strictEqual(sent.tolerations[0].value, 'diva');
+            assert.strictEqual(sent.imagePullSecrets[0].name, 'apqxdls-acr-credentials');
+        });
+
+        it('preserves initContainers, including a native sidecar', async () => {
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                podSpec: {
+                    initContainers: [{
+                        name: 'ocats-solver',
+                        image: 'solver:latest',
+                        restartPolicy: 'Always',
+                        resources: {}
+                    }],
+                    containers: [container]
+                }
+            }]));
+
+            const sent = server.getSubmittedPodSpec();
+            assert.strictEqual(sent.initContainers.length, 1);
+            assert.strictEqual(sent.initContainers[0].name, 'ocats-solver');
+            assert.strictEqual(sent.initContainers[0].restartPolicy, 'Always');
+        });
+
+        it('defaults restartPolicy to Never for batch jobs', async () => {
+            await client.submitJobs(spec([
+                { namespace: 'apqx', podSpec: { containers: [container] } }
+            ]));
+            assert.strictEqual(server.getSubmittedPodSpec().restartPolicy, 'Never');
+        });
+
+        it('honours an explicit restartPolicy', async () => {
+            await client.submitJobs(spec([
+                { namespace: 'apqx', podSpec: { restartPolicy: 'OnFailure', containers: [container] } }
+            ]));
+            assert.strictEqual(server.getSubmittedPodSpec().restartPolicy, 'OnFailure');
+        });
+    });
+
+    describe('gogo-proto embedded structs', () => {
+        it('keeps a PVC claimName, which flat YAML used to lose entirely', async () => {
+            // Volume nests its source under `volumeSource`, so a flat
+            // persistentVolumeClaim encoded to nothing but the name — and an
+            // empty VolumeSource means EmptyDir, silently turning a shared
+            // NetApp/VAST mount into empty scratch space.
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                podSpec: {
+                    volumes: [
+                        { name: 'dls-data', persistentVolumeClaim: { claimName: 'dls-data' } },
+                        { name: 'shm', emptyDir: { medium: 'Memory', sizeLimit: '64Gi' } }
+                    ],
+                    containers: [container]
+                }
+            }]));
+
+            const sent = server.getSubmittedPodSpec();
+            assert.strictEqual(
+                sent.volumes[0].volumeSource.persistentVolumeClaim.claimName,
+                'dls-data',
+                'PVC claim name must survive the wire'
+            );
+            assert.strictEqual(sent.volumes[1].volumeSource.emptyDir.medium, 'Memory');
+            // sizeLimit is a Quantity, which is a message wrapping a string.
+            assert.strictEqual(sent.volumes[1].volumeSource.emptyDir.sizeLimit.string, '64Gi');
+        });
+
+        it('keeps the secret name on a secretKeyRef env var', async () => {
+            // SecretKeySelector nests the name under `localObjectReference`, so
+            // the credential name vanished and pods started with unset AWS_* vars.
+            await client.submitJobs(spec([{
+                namespace: 'wf1',
+                podSpec: {
+                    containers: [{
+                        ...container,
+                        env: [
+                            {
+                                name: 'AWS_ACCESS_KEY_ID',
+                                valueFrom: { secretKeyRef: { name: 'wf1-vast-s3-credentials', key: 'accessKeyID' } }
+                            },
+                            {
+                                name: 'CFG',
+                                valueFrom: { configMapKeyRef: { name: 'app-config', key: 'mode' } }
+                            },
+                            { name: 'PLAIN', value: 'literal' }
+                        ]
+                    }]
+                }
+            }]));
+
+            const env = server.getSubmittedPodSpec().containers[0].env;
+            assert.strictEqual(
+                env[0].valueFrom.secretKeyRef.localObjectReference.name,
+                'wf1-vast-s3-credentials'
+            );
+            assert.strictEqual(env[0].valueFrom.secretKeyRef.key, 'accessKeyID');
+            assert.strictEqual(env[1].valueFrom.configMapKeyRef.localObjectReference.name, 'app-config');
+            assert.strictEqual(env[2].value, 'literal');
+        });
+
+        it('keeps envFrom secretRef and configMapRef names', async () => {
+            await client.submitJobs(spec([{
+                namespace: 'wf1',
+                podSpec: {
+                    containers: [{
+                        ...container,
+                        envFrom: [
+                            { secretRef: { name: 'creds' } },
+                            { configMapRef: { name: 'cfg' }, prefix: 'APP_' }
+                        ]
+                    }]
+                }
+            }]));
+
+            const envFrom = server.getSubmittedPodSpec().containers[0].envFrom;
+            assert.strictEqual(envFrom[0].secretRef.localObjectReference.name, 'creds');
+            assert.strictEqual(envFrom[1].configMapRef.localObjectReference.name, 'cfg');
+            assert.strictEqual(envFrom[1].prefix, 'APP_');
+        });
+
+        it('keeps a probe handler, which the proto nests separately', async () => {
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                podSpec: {
+                    containers: [{
+                        ...container,
+                        livenessProbe: { exec: { command: ['true'] }, periodSeconds: 10 }
+                    }]
+                }
+            }]));
+
+            const probe = server.getSubmittedPodSpec().containers[0].livenessProbe;
+            assert.deepStrictEqual(probe.handler.exec.command, ['true']);
+            assert.strictEqual(probe.periodSeconds, 10);
+        });
+    });
+
+    describe('container fields', () => {
+        it('preserves the fields the container allowlist used to drop', async () => {
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                podSpec: {
+                    containers: [{
+                        name: 'main',
+                        image: 'busybox',
+                        command: ['sh', '-c'],
+                        args: ['echo hi'],
+                        workingDir: '/work',
+                        imagePullPolicy: 'Always',
+                        terminationMessagePolicy: 'FallbackToLogsOnError',
+                        lifecycle: { preStop: { exec: { command: ['kill', '-KILL', '1'] } } },
+                        volumeMounts: [{ name: 'dls-data', mountPath: '/data' }],
+                        securityContext: { runAsUser: 7005 },
+                        resources: {}
+                    }]
+                }
+            }]));
+
+            const sent = server.getSubmittedPodSpec().containers[0];
+            assert.strictEqual(sent.workingDir, '/work');
+            assert.strictEqual(sent.terminationMessagePolicy, 'FallbackToLogsOnError');
+            assert.deepStrictEqual(sent.lifecycle.preStop.exec.command, ['kill', '-KILL', '1']);
+            assert.strictEqual(sent.volumeMounts[0].mountPath, '/data');
+            assert.strictEqual(String(sent.securityContext.runAsUser), '7005');
+            assert.deepStrictEqual(sent.command, ['sh', '-c']);
+        });
+
+        it('wraps resource quantities in every form users write', async () => {
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                podSpec: {
+                    containers: [{
+                        ...container,
+                        resources: {
+                            limits: { cpu: 16, memory: '125Gi', 'nvidia.com/gpu': 1 },
+                            requests: { cpu: '7900m', memory: '512Mi', 'ephemeral-storage': '20Gi' }
+                        }
+                    }]
+                }
+            }]));
+
+            const res = server.getSubmittedPodSpec().containers[0].resources;
+            // Unquoted numbers are valid Kubernetes and must not be lost.
+            assert.strictEqual(res.limits.cpu.string, '16');
+            assert.strictEqual(res.limits.memory.string, '125Gi');
+            assert.strictEqual(res.limits['nvidia.com/gpu'].string, '1');
+            assert.strictEqual(res.requests.cpu.string, '7900m');
+            assert.strictEqual(res.requests['ephemeral-storage'].string, '20Gi');
+        });
+
+        it('preserves container ports', async () => {
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                podSpec: {
+                    containers: [{ ...container, ports: [{ containerPort: 29500, name: 'dist' }] }]
+                }
+            }]));
+
+            const ports = server.getSubmittedPodSpec().containers[0].ports;
+            assert.strictEqual(ports[0].containerPort, 29500);
+            assert.strictEqual(ports[0].name, 'dist');
+        });
+    });
+
+    describe('job-level fields', () => {
+        it('forwards the job fields that were hand-copied before', async () => {
+            // ingress, services and scheduler are declared in the extension's own
+            // job type but never reached the server.
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                priority: 1000,
+                clientId: 'dedup-key-1',
+                scheduler: 'pulsar',
+                labels: { team: 'apqx' },
+                annotations: { 'armada/owner': 'matt' },
+                ingress: [{ ports: [8080], tlsEnabled: true }],
+                services: [{ name: 'headless', ports: [29500] }],
+                podSpec: { containers: [container] }
+            }]));
+
+            const item = server.getLastSubmitRequest().job_request_items[0];
+            assert.strictEqual(item.priority, 1000);
+            assert.strictEqual(item.namespace, 'apqx');
+            assert.strictEqual(item.client_id, 'dedup-key-1');
+            assert.strictEqual(item.scheduler, 'pulsar');
+            assert.deepStrictEqual(item.labels, { team: 'apqx' });
+            assert.deepStrictEqual(item.annotations, { 'armada/owner': 'matt' });
+            assert.strictEqual(item.ingress.length, 1);
+            assert.deepStrictEqual(item.ingress[0].ports, [8080]);
+            assert.strictEqual(item.ingress[0].tls_enabled, true);
+            assert.strictEqual(item.services[0].name, 'headless');
+            assert.deepStrictEqual(item.services[0].ports, [29500]);
+        });
+
+        it('defaults namespace and priority when omitted', async () => {
+            await client.submitJobs(spec([{ podSpec: { containers: [container] } }]));
+
+            const item = server.getLastSubmitRequest().job_request_items[0];
+            assert.strictEqual(item.namespace, 'default');
+            assert.strictEqual(item.priority, 0);
+        });
+
+        it('warns about an unknown job-level key', async () => {
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                jobSetId: 'not-a-per-job-field',
+                podSpec: { containers: [container] }
+            }]));
+
+            assert.match(logs.join('\n'), /jobSetId/);
+        });
+    });
+
+    describe('unrecognized fields', () => {
+        it('warns instead of dropping an unknown key in silence', async () => {
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                podSpec: { backoffLimit: 3, containers: [container] }
+            }]));
+
+            const joined = logs.join('\n');
+            assert.match(joined, /backoffLimit/, `expected a warning naming the key, got: ${joined}`);
+        });
+
+        it('warns about a misspelled container field', async () => {
+            await client.submitJobs(spec([{
+                namespace: 'apqx',
+                podSpec: { containers: [{ ...container, imagePullPolcy: 'Always' }] }
+            }]));
+
+            assert.match(logs.join('\n'), /imagePullPolcy/);
+        });
+
+        it('stays quiet for a fully valid spec', async () => {
+            await client.submitJobs(spec([
+                { namespace: 'apqx', podSpec: { containers: [container] } }
+            ]));
+
+            assert.ok(
+                !logs.some(m => /unrecognized/i.test(m)),
+                `no warning expected, got: ${logs.join('\n')}`
+            );
+        });
+    });
+
+    describe('per-item rejections', () => {
+        it('reports a rejected job instead of counting it as submitted', async () => {
+            // The server can accept some items and reject others inside one
+            // successful call; those rejections used to be reported as successes.
+            const response = await client.submitJobs(spec([
+                { namespace: 'apqx', podSpec: { containers: [container] } },
+                { namespace: REJECT_NAMESPACE, podSpec: { containers: [container] } }
+            ]));
+
+            assert.strictEqual(response.jobIds.length, 1);
+            assert.strictEqual(response.rejected.length, 1);
+            assert.strictEqual(response.rejected[0].index, 1);
+            assert.match(response.rejected[0].error, /not permitted/);
+        });
+
+        it('returns no job ids when every item is rejected', async () => {
+            const response = await client.submitJobs(spec([
+                { namespace: REJECT_NAMESPACE, podSpec: { containers: [container] } }
+            ]));
+
+            assert.strictEqual(response.jobIds.length, 0);
+            assert.strictEqual(response.rejected.length, 1);
+        });
+
+        it('never yields an id that stringifies to [object Object]', async () => {
+            const response = await client.submitJobs(spec([
+                { namespace: 'apqx', podSpec: { containers: [container] } }
+            ]));
+
+            for (const id of response.jobIds) {
+                assert.strictEqual(typeof id, 'string');
+                assert.notStrictEqual(id, '[object Object]');
+                assert.ok(id.length > 0);
+            }
+        });
+    });
+});

--- a/src/test/unit/vscodeMock.ts
+++ b/src/test/unit/vscodeMock.ts
@@ -38,6 +38,9 @@ export const vscodeMock = {
         showErrorMessage: async () => undefined,
         showWarningMessage: async () => undefined,
         showQuickPick: async () => undefined,
+        activeTextEditor: undefined as unknown,
+        withProgress: async (_options: unknown, task: (progress: unknown) => Promise<unknown>) =>
+            task({ report: () => undefined }),
     },
     workspace: {
         getConfiguration: () => ({ get: (_key: string, defaultVal?: unknown) => defaultVal }),

--- a/src/types/armada.ts
+++ b/src/types/armada.ts
@@ -107,8 +107,25 @@ export interface ConnectionTestResult {
  * gRPC response types
  */
 
+/** A job the server refused, with its reason. */
+export interface RejectedJob {
+    /** Index of the job in the submitted file, for pointing the user at it. */
+    index: number;
+    error: string;
+}
+
 export interface SubmitJobResponse {
+    /** Ids of the jobs the server accepted. */
     jobIds: string[];
+    /**
+     * Jobs the server rejected individually.
+     *
+     * SubmitJobs can accept some items and reject others, reporting the reason
+     * per item rather than as a call-level error. These used to be ignored, so a
+     * rejected job was counted as a success and pushed into the tree as the
+     * string "[object Object]".
+     */
+    rejected: RejectedJob[];
 }
 
 export interface JobEventMessage {


### PR DESCRIPTION
## The bug you hit

Submitting a job written the way `armadactl`, the Armada docs and **this extension's own README** write it — with a singular `podSpec:` — failed with:

```
gRPC code 3 INVALID_ARGUMENT: Job must contain at least one PodSpec
```

`convertJobToProto` read only the plural `podSpecs:` key, so the request carried an empty `pod_specs` and the server rejected it. Measured against a corpus of 25 real job files: **20 of 25 produced zero pod specs.**

(This was always broken. It only became *visible* after #70 started surfacing `error.details` — before that the same failure was an opaque `UNAVAILABLE`.)

## The worse bug underneath

The 5 files that did submit were being **altered in transit**. Both the pod spec and the job item were built by hand-copying an allowlist — 9 of PodSpec's 42 fields, 10 of Container's — and everything else was dropped without a word.

`protobuf.js` silently ignores unknown keys, so this is invisible: `Volume.verify({name, persistentVolumeClaim: {...}})` returns `null` (valid) and encodes to **10 bytes** containing nothing but the name.

| What was lost | Why | Corpus impact |
|---|---|---|
| `volumes[].persistentVolumeClaim` | The vendored gogo protos don't apply `(gogoproto.embed)`, so `Volume.volumeSource` is a real nested message while Kubernetes YAML writes its contents flat | **17 jobs** |
| `securityContext` (pod-level) | not in the allowlist | **15 jobs** |
| `priorityClassName` | not in the allowlist | **12 jobs** |
| `secretKeyRef.name` | vanished into `localObjectReference` — pods started with unset credentials | — |
| `initContainers`, `lifecycle`, `workingDir`, `serviceAccountName`, `schedulerName`, … | not in the allowlist | — |
| `ingress`, `services`, `scheduler` | declared in the extension's own job type, never forwarded | — |

The PVC one is the dangerous one: **an empty `VolumeSource` is defined to mean EmptyDir**, so a shared NetApp/VAST mount silently became empty scratch space that vanished at pod exit. The job "succeeded".

## The fix

**Descriptor-driven pass-through** (`src/grpc/podSpecConverter.ts`) replaces both allowlists: walk the loaded protobuf descriptor, so every field the proto declares is forwarded and new ones need no code change. Only the three places where the vendored protos genuinely differ from Kubernetes YAML are reshaped:

1. **Embedded structs** lifted into their wrapper — `volumeSource`, `localObjectReference`, `handler` (7 such sites reachable from PodSpec).
2. **`resource.Quantity`** wrapped — it's a message with one `string` field, so `memory: 5Gi` *and* an unquoted `cpu: 16` both work, anywhere a Quantity appears (`emptyDir.sizeLimit` too, not just `resources`).
3. **`intstr.IntOrString`** tagged with its `type`.

Field lookup accepts either casing, since Armada's own messages are snake_case (`client_id`, `tls_enabled`) while users write camelCase.

**Unknown keys are now named** in the Armada output channel instead of disappearing. This immediately found two real mistakes in existing job files — `securityContext` and `nodeSelector`/`affinity` sitting at job level instead of inside the pod spec, keys `armadactl` also ignores.

**Both `podSpec:` and `podSpecs:` are accepted**, normalized into the repeated field. A bare mapping under the plural key works too (that used to throw `job.podSpecs.map is not a function`). Never both `pod_spec` and `pod_specs` on the wire — sending both risks the server reading one as the main spec and the other as an extra gang member.

**Rejected jobs are no longer reported as successes.** `SubmitJobs` reports per-item failures inside an otherwise *successful* call, and `job_response_items[].error` was never read — the whole response array was returned as `jobIds`, so a rejection was announced as "Successfully submitted 1 jobs" and pushed into the tree as the literal string `[object Object]`. Accepted and rejected are now split (`SubmitJobResponse.rejected`), only accepted jobs enter the tree, and a partial failure reads as a warning rather than a success.

**Pre-flight validation** catches a missing pod spec before dialing the server, naming the job index and the expected key — the server's own complaint names neither.

## Verification

Corpus of 25 real job files, before vs. after (measured, not estimated):

| | before | after |
|---|---|---|
| files producing pod specs | 5 / 25 | **25 / 25** |
| PVC claims surviving encode→decode | 0 | **26** |
| `priorityClassName` preserved | 0 | **12** |
| `securityContext` preserved | 0 | **15** |
| verify/encode errors | — | **0** |
| PodSpec fields reachable | 9 / 42 | **42 / 42** |

End-to-end through the real client and a mock server that decodes the wire format: 25/25 accepted, 0 rejected.

- **121 unit tests passing** (up from 84). New: `convertJob.test.ts` (25) asserts on what the *server decoded*, not on client-side intermediates — a field the client builds but the proto discards is only visible from that side. `submitJob.test.ts` (12) covers pre-flight and the reporting split.
- **8 negative controls run**: each guard reverted individually (plural-only read, embedded lifting, Quantity wrapping, snake_case fallback, unknown-field reporting, per-item errors, raw-item `jobIds`, pre-flight, success-always reporting) — each failed exactly its intended tests and nothing else.
- typecheck clean; lint 0 errors (7 pre-existing warnings, down from 9 — no new ones); VSIX packages from a clean clone and the descriptor loads from the packaged `dist/proto` layout.

## Follow-ups not in this PR

- `schemas/armada-job-schema.json` still requires `podSpecs` and isn't bound to submittable file patterns — it's what steers people into the broken spelling.
- README Quick Start shows `contexts:` as a YAML list while `ArmadaConfig.contexts` is a `Record`.
- Client-side serialization failures surface as gRPC code 13 `INTERNAL`, indistinguishable from a server fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)