### PR TITLE
fix(grpc): stop deriving a bogus Binoculars port for TLS endpoints

### DIFF
--- a/src/grpc/armadaClient.ts
+++ b/src/grpc/armadaClient.ts
@@ -35,6 +35,53 @@ export function usesTls(url: string, forceNoTls?: boolean): boolean {
 }
 
 /**
+ * Guess the Binoculars endpoint from the Armada endpoint.
+ *
+ * The `+2` offset comes from the quickstart's NodePort layout, where every
+ * service gets its own port on a single host:
+ *   localhost:30002            -> localhost:30004
+ *   armada.example.com:50051   -> armada.example.com:50053
+ *
+ * That relationship does not exist behind a TLS reverse proxy or ingress, where
+ * all services are fronted on 443 and separated by hostname instead. Deriving
+ * there produces port 445 (SMB), and the log request fails with ECONNREFUSED —
+ * which reads as "Binoculars is down" when in truth it was never configured.
+ * The same applies to any explicit `https://` endpoint.
+ *
+ * Returns `{url: null, reason}` instead of guessing in those cases, so the
+ * caller can tell the user which setting is missing.
+ */
+export function deriveBinocularsUrl(armadaUrl: string): { url: string | null; reason: string } {
+    const urlMatch = armadaUrl.match(/^(?:(https?):\/\/)?([^:/]+)(?::(\d+))?$/);
+    if (!urlMatch) {
+        return { url: null, reason: `Could not parse the Armada URL "${armadaUrl}" to derive a Binoculars URL.` };
+    }
+
+    const [, scheme, host, portText] = urlMatch;
+    const port = portText ? parseInt(portText, 10) : null;
+
+    if (scheme === 'https' || port === 443) {
+        return {
+            url: null,
+            reason: `Cannot infer a Binoculars URL from the TLS endpoint "${armadaUrl}", because ` +
+                'services behind an ingress share one port and differ only by hostname. ' +
+                'Set binocularsUrl (or binocularsUrlPattern for multi-cluster setups) in your ' +
+                'armadactl config to view job logs.'
+        };
+    }
+
+    if (!port) {
+        return {
+            url: null,
+            reason: `The Armada URL "${armadaUrl}" has no port, so a Binoculars URL cannot be derived. ` +
+                'Set binocularsUrl in your armadactl config to view job logs.'
+        };
+    }
+
+    return { url: `${host}:${port + 2}`, reason: '' };
+}
+
+/**
  * Select gRPC channel credentials for a given endpoint URL.
  * Returns SSL credentials when the URL uses an `https://` scheme or targets
  * port 443.  Passing `forceNoTls: true` always returns insecure credentials
@@ -89,6 +136,8 @@ export class ArmadaClient {
     private jobsClient: any;
     private binocularsClient: any; // Default Binoculars client (no cluster ID)
     private binocularsClients: Map<string, any> = new Map(); // Cluster-specific Binoculars clients
+    /** Why the Binoculars URL could not be determined, surfaced by getLogs. */
+    private binocularsUrlError: string | undefined;
     private config: ResolvedConfig;
     private initialized: boolean = false;
     private cachedAuthHeader: string | undefined;
@@ -210,39 +259,20 @@ export class ArmadaClient {
     }
 
     /**
-     * Derive Binoculars URL from Armada URL
-     * Pattern: If Armada is on port X, Binoculars gRPC is typically on port X+2
-     * Examples:
-     *   localhost:30002 -> localhost:30004
-     *   armada.example.com:50051 -> armada.example.com:50053
+     * Derive a Binoculars URL from the Armada URL, logging the reason on failure.
+     * See the module-level `deriveBinocularsUrl` for why derivation is not
+     * always possible.
      */
     private deriveBinocularsUrl(armadaUrl: string): string | null {
-        try {
-            // Parse the URL
-            const urlMatch = armadaUrl.match(/^(?:https?:\/\/)?([^:]+)(?::(\d+))?$/);
-            if (!urlMatch) {
-                console.log('[Armada] Could not parse Armada URL for Binoculars derivation:', armadaUrl);
-                return null;
-            }
-
-            const host = urlMatch[1];
-            const port = urlMatch[2] ? parseInt(urlMatch[2]) : null;
-
-            if (!port) {
-                console.log('[Armada] Armada URL has no port, cannot derive Binoculars URL');
-                return null;
-            }
-
-            // Binoculars gRPC port is typically Armada gRPC port + 2
-            const binocularsPort = port + 2;
-            const binocularsUrl = `${host}:${binocularsPort}`;
-
-            console.log('[Armada] Derived Binoculars URL:', binocularsUrl);
-            return binocularsUrl;
-        } catch (error) {
-            console.error('[Armada] Error deriving Binoculars URL:', error);
+        const derived = deriveBinocularsUrl(armadaUrl);
+        if (derived.url === null) {
+            // Kept so getLogs can report why, instead of blaming Binoculars.
+            this.binocularsUrlError = derived.reason;
+            this.logWarning(derived.reason);
             return null;
         }
+        console.log('[Armada] Derived Binoculars URL:', derived.url);
+        return derived.url;
     }
 
     /**
@@ -991,7 +1021,10 @@ export class ArmadaClient {
         const binocularsClient = this.getBinocularsClientForCluster(clusterId);
 
         if (!binocularsClient) {
-            throw new Error(`Could not create Binoculars client for cluster "${clusterId}". Check your configuration.`);
+            throw new Error(
+                this.binocularsUrlError
+                    ?? `Could not create Binoculars client for cluster "${clusterId}". Check your configuration.`
+            );
         }
 
         return new Promise((resolve, reject) => {

--- a/src/test/unit/grpc/deriveBinocularsUrl.test.ts
+++ b/src/test/unit/grpc/deriveBinocularsUrl.test.ts
@@ -1,0 +1,56 @@
+import * as assert from 'assert';
+import { deriveBinocularsUrl } from '../../../grpc/armadaClient';
+
+/**
+ * The `+2` guess only describes the quickstart's NodePort layout. Behind an
+ * ingress it produced 445 (SMB) from 443, and log viewing failed with
+ * ECONNREFUSED that read as "Binoculars is down".
+ */
+describe('deriveBinocularsUrl', () => {
+    it('offsets the port by 2 for the quickstart NodePort layout', () => {
+        assert.deepStrictEqual(
+            deriveBinocularsUrl('localhost:30002'),
+            { url: 'localhost:30004', reason: '' }
+        );
+    });
+
+    it('offsets the gRPC port by 2 for a plain-text host', () => {
+        assert.strictEqual(deriveBinocularsUrl('armada.example.com:50051').url, 'armada.example.com:50053');
+    });
+
+    it('offsets the port for an explicit http:// scheme, dropping the scheme', () => {
+        assert.strictEqual(deriveBinocularsUrl('http://armada.example.com:50051').url, 'armada.example.com:50053');
+    });
+
+    it('refuses to derive from port 443 rather than guessing 445', () => {
+        const result = deriveBinocularsUrl('armada-server-grpc.tail84e79d.ts.net:443');
+        assert.strictEqual(result.url, null, 'must not guess a port for a TLS endpoint');
+        assert.ok(/binocularsUrl/.test(result.reason), `reason should name the setting to fix: ${result.reason}`);
+    });
+
+    it('refuses to derive from an https:// scheme even on a non-443 port', () => {
+        const result = deriveBinocularsUrl('https://armada.example.com:8443');
+        assert.strictEqual(result.url, null);
+        assert.ok(/binocularsUrl/.test(result.reason));
+    });
+
+    it('refuses to derive when no port is present', () => {
+        const result = deriveBinocularsUrl('armada.example.com');
+        assert.strictEqual(result.url, null);
+        assert.ok(/no port/.test(result.reason), `reason should say the port is missing: ${result.reason}`);
+    });
+
+    it('reports a parse failure for an unparseable endpoint', () => {
+        const result = deriveBinocularsUrl('not a url:::');
+        assert.strictEqual(result.url, null);
+        assert.ok(result.reason.length > 0, 'a failure must always carry a reason');
+    });
+
+    it('never returns a URL without also returning an empty reason', () => {
+        for (const url of ['localhost:30002', 'host:50051', 'http://host:1234']) {
+            const result = deriveBinocularsUrl(url);
+            assert.ok(result.url, `${url} should derive`);
+            assert.strictEqual(result.reason, '', `${url} should carry no reason on success`);
+        }
+    });
+});


### PR DESCRIPTION
## Problem

Viewing job logs against a TLS-fronted Armada failed with:

```
ERROR: Failed to get logs: 14 UNAVAILABLE: No connection established.
Last error: Error: connect ECONNREFUSED 100.98.170.90:445

Troubleshooting:
- Verify Binoculars service is running
- Check if the job has started running
- Ensure you have permissions to access logs
```

None of that troubleshooting applies. Port **445 is SMB** — it came from `deriveBinocularsUrl` adding 2 to the Armada port. `443 + 2 = 445`.

The `+2` offset describes the quickstart's NodePort layout, where every service gets its own port on a single host (`localhost:30002` → `localhost:30004`). It does not describe an ingress or reverse proxy, where all services are fronted on 443 and separated by **hostname** instead — there is no arithmetic relationship to Binoculars' port at all.

Because the derivation always "succeeded", the extension built a client for a port nothing listens on, and the resulting connection refusal was reported as though Binoculars were down. The real problem was that `binocularsUrl` had never been configured.

## Change

- Refuse to derive for `https://` or `:443` endpoints, and return the reason alongside the null result.
- Surface that reason from `getLogs`, so the error names the setting to fix rather than implying Binoculars is unhealthy.
- Move the derivation to a module-level pure function next to `stripScheme` / `usesTls`, so it is directly testable. The class keeps a thin private wrapper that handles logging.

Plain-text derivation is unchanged: `localhost:30002` → `localhost:30004` still works, so the quickstart flow is unaffected.

## Tests

New `src/test/unit/grpc/deriveBinocularsUrl.test.ts` — 8 cases covering the NodePort offset, an `http://` scheme, `:443` refusal, `https://` on a non-443 port, a missing port, an unparseable endpoint, and the invariant that a returned URL always carries an empty reason.

- `npm run test:unit` — 129 passing
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (7 pre-existing warnings in unrelated test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)